### PR TITLE
fix: frontend audit after account-level currency migration

### DIFF
--- a/web/src/features/accounts/index.tsx
+++ b/web/src/features/accounts/index.tsx
@@ -262,17 +262,12 @@ function AccountFormSheet({
   const errorMsg = friendlyError(createMut.error || updateMut.error, t)
   const canSubmit = name.trim().length > 0 && !isPending
 
-  const [showCurrencyWarning, setShowCurrencyWarning] = useState(false)
-  const currencyChanged = isEdit && editAccount!.currency_code !== currency
-
   function handleSubmit() {
-    if (!isEdit) { createMut.mutate(); return }
-    if (currencyChanged) { setShowCurrencyWarning(true); return }
-    updateMut.mutate()
+    if (isEdit) updateMut.mutate()
+    else createMut.mutate()
   }
 
   return (
-    <>
     <BottomSheet onClose={onClose}>
       <div
         className="px-5 space-y-4 overflow-y-auto no-scrollbar"
@@ -337,7 +332,13 @@ function AccountFormSheet({
           <label className="block text-[11px] font-bold text-muted uppercase tracking-widest mb-1.5">
             {t('add.select_currency')}
           </label>
-          <CurrencyPicker selected={currency} onSelect={setCurrency} />
+          {isEdit ? (
+            <div className="px-3 py-1.5 rounded-full bg-accent-subtle text-accent text-[12px] font-bold inline-block">
+              {currency}
+            </div>
+          ) : (
+            <CurrencyPicker selected={currency} onSelect={setCurrency} />
+          )}
         </div>
 
         {/* Color picker */}
@@ -393,42 +394,6 @@ function AccountFormSheet({
         )}
       </div>
     </BottomSheet>
-
-    <AnimatePresence>
-      {showCurrencyWarning && (
-        <BottomSheet onClose={() => setShowCurrencyWarning(false)}>
-          <div className="px-5 pt-2 pb-8 flex flex-col gap-4 items-center text-center">
-            <div className="w-12 h-12 rounded-2xl bg-accent-subtle flex items-center justify-center text-2xl">
-              💱
-            </div>
-            <p className="text-base font-bold text-text">
-              {t('accountForm.currency_change_title')}
-            </p>
-            <p className="text-sm text-muted leading-relaxed">
-              {t('accountForm.currency_change_desc', {
-                oldCurrency: editAccount!.currency_code,
-                newCurrency: currency,
-              })}
-            </p>
-            <div className="w-full flex flex-col gap-2">
-              <button
-                onClick={() => { setShowCurrencyWarning(false); updateMut.mutate() }}
-                className="w-full py-4 rounded-2xl bg-accent text-accent-text font-bold text-[15px] active:scale-[0.98] transition-transform"
-              >
-                {t('accountForm.currency_change_confirm', { newCurrency: currency })}
-              </button>
-              <button
-                onClick={() => setShowCurrencyWarning(false)}
-                className="w-full py-4 rounded-2xl bg-surface text-muted font-semibold text-sm active:scale-[0.98] transition-transform"
-              >
-                {t('common.cancel')}
-              </button>
-            </div>
-          </div>
-        </BottomSheet>
-      )}
-    </AnimatePresence>
-    </>
   )
 }
 
@@ -442,16 +407,14 @@ function AccountRow({
 }: {
   account: Account
   onEdit: (a: Account) => void
-  onDelete: (id: number) => void
+  onDelete?: (id: number) => void
   onSetDefault: (id: number) => void
   isDeleting: boolean
 }) {
   const { t } = useTranslation()
   const TypeIcon = ACCOUNT_TYPE_ICONS[account.type]
 
-  return (
-    <div className={`transition-opacity ${isDeleting ? 'opacity-30 pointer-events-none' : ''}`}>
-      <ActionRow onDelete={() => onDelete(account.id)}>
+  const content = (
         <div className="flex items-center gap-3 px-4 py-3">
           {/* Icon */}
           <div
@@ -494,7 +457,11 @@ function AccountRow({
             </button>
           )}
         </div>
-      </ActionRow>
+  )
+
+  return (
+    <div className={`transition-opacity ${isDeleting ? 'opacity-30 pointer-events-none' : ''}`}>
+      {onDelete ? <ActionRow onDelete={() => onDelete(account.id)}>{content}</ActionRow> : content}
     </div>
   )
 }
@@ -568,7 +535,7 @@ export function AccountsPage() {
                   key={account.id}
                   account={account}
                   onEdit={setEditingAccount}
-                  onDelete={id => deleteMut.mutate(id)}
+                  onDelete={accounts.length > 1 ? id => deleteMut.mutate(id) : undefined}
                   onSetDefault={id => setDefaultMut.mutate(id)}
                   isDeleting={deletingId === account.id}
                 />

--- a/web/src/features/recurring/index.tsx
+++ b/web/src/features/recurring/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
@@ -6,6 +6,7 @@ import { AnimatePresence } from 'framer-motion'
 import { Plus, Pause, Play, ArrowsClockwise } from '@phosphor-icons/react'
 import { fetchRecurring, createRecurring, updateRecurring, toggleRecurring, deleteRecurring } from '../../shared/api/recurring'
 import { categoriesApi } from '../../shared/api/categories'
+import { accountsApi } from '../../shared/api/accounts'
 import { formatCents, parseCents, formatDate, sanitizeAmount } from '../../shared/lib/money'
 import { friendlyError } from '../../shared/lib/errors'
 import { CategoryIcon } from '../../shared/lib/categoryIcons'
@@ -15,6 +16,7 @@ import { PageTransition } from '../../shared/ui/PageTransition'
 import { useTgBackButton } from '../../shared/hooks/useTelegramApp'
 import { useHaptic } from '../../shared/hooks/useHaptic'
 import { Badge, EmptyState, ActionRow, FAB, BottomSheet } from '../../shared/ui'
+import { AccountDropdown } from '../../shared/ui/AccountDropdown'
 import { useCategoryName } from '../../shared/hooks/useCategoryName'
 import { useBaseCurrency } from '../../shared/hooks/useBaseCurrency'
 import { CurrencyBadge } from '../../shared/lib/currencyIcons'
@@ -101,7 +103,7 @@ function RecurringForm({
   const qc = useQueryClient()
   const { notification } = useHaptic()
   const tCategory = useCategoryName()
-  const { code: currencyCode } = useBaseCurrency()
+  const { code: baseCurrency } = useBaseCurrency()
 
   const isEdit = editItem !== null
 
@@ -110,13 +112,25 @@ function RecurringForm({
   const [categoryID, setCategoryID] = useState<number | null>(editItem?.category_id ?? null)
   const [note, setNote] = useState(editItem?.note ?? '')
   const [frequency, setFrequency] = useState(editItem?.frequency ?? 'monthly')
+  const [accountID, setAccountID] = useState<number | null>(editItem?.account_id ?? null)
 
+  const { data: accounts = [] } = useQuery({ queryKey: ['accounts'], queryFn: accountsApi.list })
   const catsQ = useQuery({ queryKey: ['categories'], queryFn: () => categoriesApi.list() })
   const categories = catsQ.data?.categories ?? []
   const filtered = categories.filter(c => c.type === type || c.type === 'both')
 
+  useEffect(() => {
+    if (accounts.length === 0) return
+    const def = accounts.find(a => a.is_default) ?? accounts[0]
+    if (accountID === null) setAccountID(def.id)
+  }, [accounts]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const selectedAccount = accounts.find(a => a.id === accountID)
+  const currencyCode = selectedAccount?.currency_code ?? baseCurrency
+
   const createMut = useMutation({
     mutationFn: () => createRecurring({
+      account_id: accountID!,
       type,
       amount_cents: parseCents(amount),
       currency_code: currencyCode,
@@ -133,6 +147,7 @@ function RecurringForm({
 
   const updateMut = useMutation({
     mutationFn: () => updateRecurring(editItem!.id, {
+      account_id: accountID!,
       type,
       amount_cents: parseCents(amount),
       currency_code: currencyCode,
@@ -148,7 +163,7 @@ function RecurringForm({
   })
 
   const mut = isEdit ? updateMut : createMut
-  const canSubmit = parseCents(amount) > 0 && categoryID !== null && !mut.isPending
+  const canSubmit = parseCents(amount) > 0 && categoryID !== null && accountID !== null && !mut.isPending
 
   return (
     <BottomSheet onClose={onClose}>
@@ -174,6 +189,17 @@ function RecurringForm({
             </button>
           ))}
         </div>
+
+        {/* Account */}
+        {accounts.length > 0 && accountID !== null && (
+          <AccountDropdown
+            accounts={accounts}
+            selectedId={accountID}
+            onChange={id => id !== null && setAccountID(id)}
+            showBalance
+            variant="surface"
+          />
+        )}
 
         {/* Amount */}
         <div>

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "سعر الصرف غير متاح مؤقتاً.",
     "too_many_currencies": "الحد الأقصى 3 عملات للعرض.",
     "invalid_currency": "رمز العملة غير صالح.",
-    "invalid_amount": "تم إدخال مبلغ غير صالح."
+    "invalid_amount": "تم إدخال مبلغ غير صالح.",
+    "cannot_delete_last_account": "لا يمكن حذف الحساب الوحيد.",
+    "must_set_new_default": "عيّن حساباً آخر كافتراضي قبل حذف هذا الحساب.",
+    "currency_immutable": "لا يمكن تغيير عملة الحساب بعد الإنشاء."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/be.json
+++ b/web/src/i18n/locales/be.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Курс валют часова недаступны.",
     "too_many_currencies": "Максімум 3 адлюстроўваемыя валюты.",
     "invalid_currency": "Няправільны код валюты.",
-    "invalid_amount": "Уведзена некарэктная сума."
+    "invalid_amount": "Уведзена некарэктная сума.",
+    "cannot_delete_last_account": "Немагчыма выдаліць адзіны рахунак.",
+    "must_set_new_default": "Спачатку прызначце іншы рахунак асноўным, перш чым выдаляць гэты.",
+    "currency_immutable": "Валюту рахунку нельга змяніць пасля стварэння."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Wechselkurs vorübergehend nicht verfügbar.",
     "too_many_currencies": "Maximal 3 Anzeigewährungen erlaubt.",
     "invalid_currency": "Ungültiger Währungscode.",
-    "invalid_amount": "Ungültiger Betrag eingegeben."
+    "invalid_amount": "Ungültiger Betrag eingegeben.",
+    "cannot_delete_last_account": "Das einzige Konto kann nicht gelöscht werden.",
+    "must_set_new_default": "Lege zuerst ein anderes Konto als Standard fest, bevor du dieses löschst.",
+    "currency_immutable": "Die Kontowährung kann nach der Erstellung nicht geändert werden."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -295,7 +295,10 @@
     "exchange_rate_unavailable": "Exchange rate temporarily unavailable.",
     "too_many_currencies": "Maximum 3 display currencies allowed.",
     "invalid_currency": "Invalid currency code.",
-    "invalid_amount": "Invalid amount entered."
+    "invalid_amount": "Invalid amount entered.",
+    "cannot_delete_last_account": "Cannot delete the only account.",
+    "must_set_new_default": "Set a different account as default before deleting this one.",
+    "currency_immutable": "Account currency cannot be changed after creation."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "El tipo de cambio no está disponible temporalmente.",
     "too_many_currencies": "Máximo 3 monedas para mostrar.",
     "invalid_currency": "Código de moneda inválido.",
-    "invalid_amount": "Importe inválido introducido."
+    "invalid_amount": "Importe inválido introducido.",
+    "cannot_delete_last_account": "No se puede eliminar la única cuenta.",
+    "must_set_new_default": "Establece otra cuenta como predeterminada antes de eliminar esta.",
+    "currency_immutable": "La moneda de la cuenta no se puede cambiar después de la creación."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Taux de change temporairement indisponible.",
     "too_many_currencies": "Maximum 3 devises d'affichage autorisées.",
     "invalid_currency": "Code de devise invalide.",
-    "invalid_amount": "Montant invalide saisi."
+    "invalid_amount": "Montant invalide saisi.",
+    "cannot_delete_last_account": "Impossible de supprimer le seul compte.",
+    "must_set_new_default": "Définissez un autre compte par défaut avant de supprimer celui-ci.",
+    "currency_immutable": "La devise du compte ne peut pas être modifiée après la création."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Kurs pertukaran sementara tidak tersedia.",
     "too_many_currencies": "Maksimal 3 mata uang tampilan diizinkan.",
     "invalid_currency": "Kode mata uang tidak valid.",
-    "invalid_amount": "Jumlah tidak valid dimasukkan."
+    "invalid_amount": "Jumlah tidak valid dimasukkan.",
+    "cannot_delete_last_account": "Tidak dapat menghapus satu-satunya akun.",
+    "must_set_new_default": "Tetapkan akun lain sebagai default sebelum menghapus yang ini.",
+    "currency_immutable": "Mata uang akun tidak dapat diubah setelah dibuat."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Tasso di cambio temporaneamente non disponibile.",
     "too_many_currencies": "Massimo 3 valute da visualizzare.",
     "invalid_currency": "Codice valuta non valido.",
-    "invalid_amount": "Importo non valido inserito."
+    "invalid_amount": "Importo non valido inserito.",
+    "cannot_delete_last_account": "Impossibile eliminare l'unico conto.",
+    "must_set_new_default": "Imposta un altro conto come predefinito prima di eliminare questo.",
+    "currency_immutable": "La valuta del conto non può essere modificata dopo la creazione."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/kk.json
+++ b/web/src/i18n/locales/kk.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Валюта бағамы уақытша қол жетімсіз.",
     "too_many_currencies": "Максимум 3 валюта көрсетілуі мүмкін.",
     "invalid_currency": "Жарамсыз валюта коды.",
-    "invalid_amount": "Жарамсыз сома енгізілді."
+    "invalid_amount": "Жарамсыз сома енгізілді.",
+    "cannot_delete_last_account": "Жалғыз шотты жою мүмкін емес.",
+    "must_set_new_default": "Осы шотты жоймас бұрын басқа шотты негізгі етіп тағайындаңыз.",
+    "currency_immutable": "Шот валютасын жасалғаннан кейін өзгерту мүмкін емес."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "환율이 일시적으로 이용할 수 없습니다.",
     "too_many_currencies": "최대 3개의 표시 통화가 허용됩니다.",
     "invalid_currency": "유효하지 않은 통화 코드입니다.",
-    "invalid_amount": "유효하지 않은 금액이 입력되었습니다."
+    "invalid_amount": "유효하지 않은 금액이 입력되었습니다.",
+    "cannot_delete_last_account": "유일한 계좌는 삭제할 수 없습니다.",
+    "must_set_new_default": "이 계좌를 삭제하기 전에 다른 계좌를 기본으로 설정하세요.",
+    "currency_immutable": "계좌 통화는 생성 후 변경할 수 없습니다."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/ms.json
+++ b/web/src/i18n/locales/ms.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Kadar pertukaran tidak tersedia buat sementara waktu.",
     "too_many_currencies": "Maksimum 3 mata wang paparan dibenarkan.",
     "invalid_currency": "Kod mata wang tidak sah.",
-    "invalid_amount": "Jumlah tidak sah dimasukkan."
+    "invalid_amount": "Jumlah tidak sah dimasukkan.",
+    "cannot_delete_last_account": "Tidak boleh memadamkan akaun satu-satunya.",
+    "must_set_new_default": "Tetapkan akaun lain sebagai lalai sebelum memadamkan yang ini.",
+    "currency_immutable": "Mata wang akaun tidak boleh ditukar selepas dicipta."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Wisselkoers tijdelijk niet beschikbaar.",
     "too_many_currencies": "Maximaal 3 weergavevaluta's toegestaan.",
     "invalid_currency": "Ongeldige valutacode.",
-    "invalid_amount": "Ongeldig bedrag ingevoerd."
+    "invalid_amount": "Ongeldig bedrag ingevoerd.",
+    "cannot_delete_last_account": "De enige rekening kan niet worden verwijderd.",
+    "must_set_new_default": "Stel eerst een andere rekening in als standaard voordat je deze verwijdert.",
+    "currency_immutable": "De valuta van de rekening kan niet worden gewijzigd na aanmaak."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Taxa de câmbio temporariamente indisponível.",
     "too_many_currencies": "Máximo 3 moedas de exibição permitidas.",
     "invalid_currency": "Código de moeda inválido.",
-    "invalid_amount": "Valor inválido inserido."
+    "invalid_amount": "Valor inválido inserido.",
+    "cannot_delete_last_account": "Não é possível excluir a única conta.",
+    "must_set_new_default": "Defina outra conta como padrão antes de excluir esta.",
+    "currency_immutable": "A moeda da conta não pode ser alterada após a criação."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -295,7 +295,10 @@
     "exchange_rate_unavailable": "Курс валют временно недоступен.",
     "too_many_currencies": "Максимум 3 отображаемые валюты.",
     "invalid_currency": "Неверный код валюты.",
-    "invalid_amount": "Введена некорректная сумма."
+    "invalid_amount": "Введена некорректная сумма.",
+    "cannot_delete_last_account": "Невозможно удалить единственный счёт.",
+    "must_set_new_default": "Сначала назначьте другой счёт основным, прежде чем удалять этот.",
+    "currency_immutable": "Валюту счёта нельзя изменить после создания."
   },
   "accountForm": {
     "currency_change_title": "Сменить валюту счёта?",

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Döviz kuru geçici olarak mevcut değil.",
     "too_many_currencies": "En fazla 3 görüntüleme para birimi izin verilir.",
     "invalid_currency": "Geçersiz para birimi kodu.",
-    "invalid_amount": "Geçersiz tutar girildi."
+    "invalid_amount": "Geçersiz tutar girildi.",
+    "cannot_delete_last_account": "Tek hesap silinemez.",
+    "must_set_new_default": "Bu hesabı silmeden önce başka bir hesabı varsayılan olarak ayarlayın.",
+    "currency_immutable": "Hesap para birimi oluşturulduktan sonra değiştirilemez."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Курс валют тимчасово недоступний.",
     "too_many_currencies": "Максимум 3 відображувані валюти.",
     "invalid_currency": "Невірний код валюти.",
-    "invalid_amount": "Введена некоректна сума."
+    "invalid_amount": "Введена некоректна сума.",
+    "cannot_delete_last_account": "Неможливо видалити єдиний рахунок.",
+    "must_set_new_default": "Спочатку призначте інший рахунок основним, перш ніж видаляти цей.",
+    "currency_immutable": "Валюту рахунку не можна змінити після створення."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/i18n/locales/uz.json
+++ b/web/src/i18n/locales/uz.json
@@ -272,7 +272,10 @@
     "exchange_rate_unavailable": "Valyuta kursi vaqtincha mavjud emas.",
     "too_many_currencies": "Maksimal 3 ta valyuta ko'rsatilishi mumkin.",
     "invalid_currency": "Noto'g'ri valyuta kodi.",
-    "invalid_amount": "Noto'g'ri summa kiritildi."
+    "invalid_amount": "Noto'g'ri summa kiritildi.",
+    "cannot_delete_last_account": "Yagona hisobni o'chirib bo'lmaydi.",
+    "must_set_new_default": "Bu hisobni o'chirishdan oldin boshqa hisobni asosiy qilib belgilang.",
+    "currency_immutable": "Hisob valyutasini yaratilgandan keyin o'zgartirib bo'lmaydi."
   },
   "accountForm": {
     "currency_change_title": "Change account currency?",

--- a/web/src/mocks/data.ts
+++ b/web/src/mocks/data.ts
@@ -97,10 +97,10 @@ export const mockBudgets: BudgetsResponse = {
 
 export const mockRecurring: RecurringListResponse = {
   recurring: [
-    { id: 1, type: 'expense', amount_cents: 75000, currency_code: 'USD', category_id: 8, category_name: 'Rent', category_icon: 'house', category_color: '#f97316', note: 'Monthly rent', frequency: 'monthly', next_run_at: daysAgo(-5), is_active: true, created_at: daysAgo(60) },
-    { id: 2, type: 'expense', amount_cents: 1500, currency_code: 'USD', category_id: 10, category_name: 'Bills', category_icon: 'device-mobile', category_color: '#64748b', note: 'Spotify subscription', frequency: 'monthly', next_run_at: daysAgo(-12), is_active: true, created_at: daysAgo(90) },
-    { id: 3, type: 'income', amount_cents: 250000, currency_code: 'USD', category_id: 6, category_name: 'Salary', category_icon: 'money', category_color: '#10b981', note: 'Monthly salary', frequency: 'monthly', next_run_at: daysAgo(-2), is_active: true, created_at: daysAgo(120) },
-    { id: 4, type: 'expense', amount_cents: 500, currency_code: 'USD', category_id: 9, category_name: 'Coffee', category_icon: 'coffee', category_color: '#eab308', note: 'Daily coffee', frequency: 'daily', next_run_at: daysAgo(-1), is_active: false, created_at: daysAgo(30) },
+    { id: 1, type: 'expense', amount_cents: 75000, currency_code: 'USD', account_id: 1, category_id: 8, category_name: 'Rent', category_icon: 'house', category_color: '#f97316', note: 'Monthly rent', frequency: 'monthly', next_run_at: daysAgo(-5), is_active: true, created_at: daysAgo(60) },
+    { id: 2, type: 'expense', amount_cents: 1500, currency_code: 'USD', account_id: 1, category_id: 10, category_name: 'Bills', category_icon: 'device-mobile', category_color: '#64748b', note: 'Spotify subscription', frequency: 'monthly', next_run_at: daysAgo(-12), is_active: true, created_at: daysAgo(90) },
+    { id: 3, type: 'income', amount_cents: 250000, currency_code: 'USD', account_id: 1, category_id: 6, category_name: 'Salary', category_icon: 'money', category_color: '#10b981', note: 'Monthly salary', frequency: 'monthly', next_run_at: daysAgo(-2), is_active: true, created_at: daysAgo(120) },
+    { id: 4, type: 'expense', amount_cents: 500, currency_code: 'USD', account_id: 1, category_id: 9, category_name: 'Coffee', category_icon: 'coffee', category_color: '#eab308', note: 'Daily coffee', frequency: 'daily', next_run_at: daysAgo(-1), is_active: false, created_at: daysAgo(30) },
   ],
 }
 

--- a/web/src/shared/api/recurring.ts
+++ b/web/src/shared/api/recurring.ts
@@ -6,6 +6,7 @@ export function fetchRecurring(): Promise<RecurringListResponse> {
 }
 
 export function createRecurring(body: {
+  account_id: number
   type: string
   amount_cents: number
   currency_code: string
@@ -17,6 +18,7 @@ export function createRecurring(body: {
 }
 
 export function updateRecurring(id: number, body: {
+  account_id?: number
   type?: string
   amount_cents?: number
   currency_code?: string

--- a/web/src/shared/lib/errors.ts
+++ b/web/src/shared/lib/errors.ts
@@ -12,6 +12,9 @@ const ERROR_KEY_MAP: Array<[string, string]> = [
   ['maximum 3 display currencies', 'errors.too_many_currencies'],
   ['invalid currency', 'errors.invalid_currency'],
   ['invalid amount', 'errors.invalid_amount'],
+  ['cannot delete the only account', 'errors.cannot_delete_last_account'],
+  ['set a new default account', 'errors.must_set_new_default'],
+  ['currency cannot be changed', 'errors.currency_immutable'],
 ]
 
 /** Returns a localized, user-friendly message for an API error.

--- a/web/src/shared/types/index.ts
+++ b/web/src/shared/types/index.ts
@@ -21,7 +21,7 @@ export interface Transaction {
   category_color: string
   note: string
   created_at: string
-  account_id?: number
+  account_id: number
   account_name?: string
   is_adjustment?: boolean
 }
@@ -111,6 +111,7 @@ export interface RecurringTransaction {
   type: TransactionType
   amount_cents: number
   currency_code: string
+  account_id: number
   category_id: number
   category_name: string
   category_icon: string


### PR DESCRIPTION
Add account picker to recurring form, enforce currency immutability in account edit, prevent deleting last account, and add missing error mappings with translations for all 17 locales.