### PR TITLE
fix(#33): clamp donut chart segment dash to prevent full-ring overdraw

### DIFF
--- a/web/src/features/stats/index.tsx
+++ b/web/src/features/stats/index.tsx
@@ -70,6 +70,9 @@ function DonutChart({
   let accumulated = 0
   const segments = data.map((d, i) => {
     const segLen = (d.percent / 100) * circumference
+    // Clamp to non-negative: a negative dasharray renders as a full ring and overdraws prior segments.
+    const dashLen = Math.max(segLen - 2, 0)
+    const gapLen = circumference - dashLen
     const offset = circumference - accumulated
     accumulated += segLen
 
@@ -83,10 +86,10 @@ function DonutChart({
         stroke={d.category_color || CHART_COLORS[i % CHART_COLORS.length]}
         strokeWidth={strokeWidth}
         strokeLinecap="round"
-        strokeDasharray={`${segLen - 2} ${circumference - segLen + 2}`}
+        strokeDasharray={`${dashLen} ${gapLen}`}
         strokeDashoffset={offset}
         initial={{ opacity: 0, strokeDasharray: `0 ${circumference}` }}
-        animate={{ opacity: 1, strokeDasharray: `${segLen - 2} ${circumference - segLen + 2}` }}
+        animate={{ opacity: 1, strokeDasharray: `${dashLen} ${gapLen}` }}
         exit={{ opacity: 0, strokeDasharray: `0 ${circumference}` }}
         transition={{ duration: 0.6, delay: i * 0.08, ease: 'easeOut' }}
       />


### PR DESCRIPTION
Closes #33

## Что сделано
- В `DonutChart` (`web/src/features/stats/index.tsx`) первый компонент `strokeDasharray` для каждого сегмента считался как `segLen - 2`. Когда `segLen < 2` (категория < ~0.64% от суммы), значение становилось отрицательным — SVG в этом случае рендерит штрих как полное кольцо, и последний `<motion.circle>` (рисуется поверх предыдущих) перекрашивает весь круг в свой цвет.
- Заменил формулу: `dashLen = Math.max(segLen - 2, 0)`, `gapLen = circumference - dashLen`. Используется и в статическом `strokeDasharray`, и в Framer Motion `animate`-target — иначе баг мигнул бы во время входной анимации.
- Поведение для нормальных сегментов (≥0.64%) не меняется. Крошечные сегменты схлопываются в `dashLen=0` и с `strokeLinecap="round"` рисуются как маленькая точка, не перекрывая остальное.

## Как проверить
- [ ] Открыть `/stats` для периода с категорией <1% от суммы (например, `Этот месяц` с разнокалиберными категориями) → круг показывает несколько цветных сегментов, цвета совпадают со списком категорий ниже.
- [ ] Сравнить с воспроизведением на `develop` (до фикса) → весь круг был одного цвета (как в скриншоте issue #33).
- [ ] `cd web && npm run build` — собирается без ошибок.

## Out of scope (на отдельные issue)
- ~12 системных категорий до сих пор имеют дефолтный `#6366f1` из миграции 00011 (Coffee, Bills, Education, Travel, Gifts, Sport, Beauty, Pets, Business, Investments, Freelance, Rent) — миграция 00021 их пропустила. После этого фикса круг рендерит сегменты раздельно, но если у пользователя несколько таких категорий, они всё равно одного индиго цвета. Стоит отдельная миграция.
- Фронтовая тестовая инфраструктура (vitest + RTL) — отсутствует во всём проекте; добавление ради одной правки `Math.max` непропорционально задаче.