### PR TITLE
feat(#35): add animation toggle for money amounts

### DIFF
--- a/web/src/features/dashboard/index.tsx
+++ b/web/src/features/dashboard/index.tsx
@@ -9,19 +9,31 @@ import { balanceApi } from '../../shared/api/balance'
 import { transactionsApi } from '../../shared/api/transactions'
 import { accountsApi } from '../../shared/api/accounts'
 import { useBaseCurrency } from '../../shared/hooks/useBaseCurrency'
+import { useAnimateNumbers } from '../../shared/hooks/useAnimateNumbers'
 import { Spinner } from '../../shared/ui/Spinner'
 import { ErrorMessage } from '../../shared/ui/ErrorMessage'
 import { PageTransition } from '../../shared/ui/PageTransition'
 import { TransactionRow, EditTransactionSheet, AccountDropdown, EmptyState } from '../../shared/ui'
 import type { Transaction } from '../../shared/types'
 
+type MoneyProps = { cents: number; currency: string; className?: string }
+
+/** Picks between spring-animated and static rendering based on user preference. */
+function AnimatedMoney(props: MoneyProps) {
+  const [animate] = useAnimateNumbers()
+  return animate ? <SpringMoney {...props} /> : <StaticMoney {...props} />
+}
+
+function StaticMoney({ cents, currency, className }: MoneyProps) {
+  return <span className={className}>{formatCents(cents, currency)}</span>
+}
+
 /** Animates a numeric cents value with a spring, formatted via formatCents */
-function AnimatedMoney({ cents, currency, className }: { cents: number; currency: string; className?: string }) {
+function SpringMoney({ cents, currency, className }: MoneyProps) {
   const spring = useSpring(cents, { stiffness: 70, damping: 18 })
   const formatterRef = useRef((v: number) => formatCents(Math.round(v), currency))
   const [display, setDisplay] = useState(() => formatCents(cents, currency))
 
-  // Update formatter ref when currency changes
   formatterRef.current = (v: number) => formatCents(Math.round(v), currency)
 
   useEffect(() => {

--- a/web/src/features/settings/index.tsx
+++ b/web/src/features/settings/index.tsx
@@ -4,13 +4,14 @@ import { useNavigate } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Check, X, Globe, CaretRight, Trash, Desktop, Sun, Moon, Bell, RepeatOnce, CalendarCheck, Trophy } from '@phosphor-icons/react'
+import { Check, X, Globe, CaretRight, Trash, Desktop, Sun, Moon, Bell, RepeatOnce, CalendarCheck, Trophy, Sparkle } from '@phosphor-icons/react'
 import { settingsApi } from '../../shared/api/settings'
 import { LANGUAGES } from '../../shared/lib/constants'
 import { Spinner } from '../../shared/ui/Spinner'
 import { ErrorMessage } from '../../shared/ui/ErrorMessage'
 import { PageTransition } from '../../shared/ui/PageTransition'
 import { useTgBackButton, useThemePreference } from '../../shared/hooks/useTelegramApp'
+import { useAnimateNumbers } from '../../shared/hooks/useAnimateNumbers'
 import { useHaptic } from '../../shared/hooks/useHaptic'
 import { FIRST_LAUNCH_KEY } from '../../shared/hooks/useFirstLaunchSetup'
 import type { ThemePref } from '../../shared/hooks/useTelegramApp'
@@ -89,6 +90,7 @@ export function SettingsPage() {
   const { selection, notification } = useHaptic()
   const [modal, setModal] = useState<Modal>('none')
   const [themePref, setThemePref] = useThemePreference()
+  const [animateNumbers, setAnimateNumbers] = useAnimateNumbers()
 
   const THEME_OPTIONS: { value: ThemePref; labelKey: string; icon: React.ElementType }[] = [
     { value: 'system', labelKey: 'settings.theme_system', icon: Desktop },
@@ -188,6 +190,36 @@ export function SettingsPage() {
                       </button>
                     )
                   })}
+                </div>
+              </div>
+
+              {/* Display & Behavior section */}
+              <div className="card-elevated">
+                <div className="px-4 pt-4 pb-2">
+                  <p className="text-[11px] font-bold text-muted uppercase tracking-widest">
+                    {t('settings.display')}
+                  </p>
+                </div>
+                <div className="flex items-center gap-4 px-4 py-3.5">
+                  <div className="w-9 h-9 rounded-xl bg-accent/10 flex items-center justify-center shrink-0">
+                    <Sparkle size={18} weight="fill" className="text-accent" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-[13px] font-semibold text-text leading-tight">
+                      {t('settings.animate_numbers')}
+                    </p>
+                    <p className="text-[11px] text-muted mt-0.5 leading-tight">
+                      {t('settings.animate_numbers_desc')}
+                    </p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={animateNumbers}
+                    onClick={() => { selection(); setAnimateNumbers(!animateNumbers) }}
+                    className={`relative shrink-0 w-11 h-6 rounded-full transition-colors duration-200 ${animateNumbers ? 'bg-accent' : 'bg-border'}`}
+                  >
+                    <span className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${animateNumbers ? 'translate-x-5' : 'translate-x-0'}`} />
+                  </button>
                 </div>
               </div>
 

--- a/web/src/features/stats/index.tsx
+++ b/web/src/features/stats/index.tsx
@@ -15,6 +15,7 @@ import { PageTransition } from '../../shared/ui/PageTransition'
 import { EmptyState, RangeDateModal } from '../../shared/ui'
 import { AccountDropdown } from '../../shared/ui/AccountDropdown'
 import { useCategoryName } from '../../shared/hooks/useCategoryName'
+import { useAnimateNumbers } from '../../shared/hooks/useAnimateNumbers'
 import type { TransactionType, CategoryStat } from '../../shared/types'
 
 type Period = 'month' | 'week' | 'today' | 'lastmonth'
@@ -24,8 +25,19 @@ interface CustomRange {
   to: string
 }
 
+type NumberProps = { value: number; formatter?: (v: number) => string }
+
 /* ─── Animated Number Counter ─── */
-function AnimatedNumber({ value, formatter }: { value: number; formatter?: (v: number) => string }) {
+function AnimatedNumber(props: NumberProps) {
+  const [animate] = useAnimateNumbers()
+  return animate ? <SpringNumber {...props} /> : <StaticNumber {...props} />
+}
+
+function StaticNumber({ value, formatter }: NumberProps) {
+  return <span>{formatter ? formatter(value) : value.toString()}</span>
+}
+
+function SpringNumber({ value, formatter }: NumberProps) {
   const spring = useSpring(0, { stiffness: 80, damping: 20 })
   const formatterRef = useRef(formatter)
   formatterRef.current = formatter

--- a/web/src/i18n/locales/ar.json
+++ b/web/src/i18n/locales/ar.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "ملخص أسبوعي",
     "notify_weekly_summary_desc": "مراجعة الإنفاق كل يوم اثنين",
     "notify_goal_milestones": "إنجازات الأهداف",
-    "notify_goal_milestones_desc": "تنبيه عند 25% و50% و75% و100%"
+    "notify_goal_milestones_desc": "تنبيه عند 25% و50% و75% و100%",
+    "display": "العرض",
+    "animate_numbers": "تحريك الأرقام",
+    "animate_numbers_desc": "تأثير نابض عند تغيّر الرصيد والمجاميع"
   },
   "more": {
     "title": "المزيد",

--- a/web/src/i18n/locales/be.json
+++ b/web/src/i18n/locales/be.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Вынік тыдня",
     "notify_weekly_summary_desc": "Панядзелкавы агляд расходаў за тыдзень",
     "notify_goal_milestones": "Дасягненні мэт",
-    "notify_goal_milestones_desc": "Апавяшчэнне пры 25%, 50%, 75%, 100% мэты"
+    "notify_goal_milestones_desc": "Апавяшчэнне пры 25%, 50%, 75%, 100% мэты",
+    "display": "Адлюстраванне",
+    "animate_numbers": "Анімацыя лікаў",
+    "animate_numbers_desc": "Плыўная анімацыя пры змене балансу і сум"
   },
   "more": {
     "title": "Яшчэ",

--- a/web/src/i18n/locales/de.json
+++ b/web/src/i18n/locales/de.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Wochenzusammenfassung",
     "notify_weekly_summary_desc": "Montags-Rückblick auf die Wochenausgaben",
     "notify_goal_milestones": "Zielerreichungen",
-    "notify_goal_milestones_desc": "Benachrichtigung bei 25%, 50%, 75%, 100%"
+    "notify_goal_milestones_desc": "Benachrichtigung bei 25%, 50%, 75%, 100%",
+    "display": "Anzeige",
+    "animate_numbers": "Zahlen animieren",
+    "animate_numbers_desc": "Federeffekt bei Änderung von Saldo und Summen"
   },
   "more": {
     "title": "Mehr",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -231,7 +231,10 @@
     "notify_weekly_summary": "Weekly Summary",
     "notify_weekly_summary_desc": "Monday recap of last week spending",
     "notify_goal_milestones": "Goal Milestones",
-    "notify_goal_milestones_desc": "Alert at 25%, 50%, 75%, 100% of a goal"
+    "notify_goal_milestones_desc": "Alert at 25%, 50%, 75%, 100% of a goal",
+    "display": "Display",
+    "animate_numbers": "Animate numbers",
+    "animate_numbers_desc": "Spring effect when balance and totals change"
   },
   "more": {
     "title": "More",

--- a/web/src/i18n/locales/es.json
+++ b/web/src/i18n/locales/es.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Resumen semanal",
     "notify_weekly_summary_desc": "Resumen del lunes sobre el gasto semanal",
     "notify_goal_milestones": "Hitos de objetivos",
-    "notify_goal_milestones_desc": "Alerta al 25%, 50%, 75%, 100% de un objetivo"
+    "notify_goal_milestones_desc": "Alerta al 25%, 50%, 75%, 100% de un objetivo",
+    "display": "Visualización",
+    "animate_numbers": "Animar números",
+    "animate_numbers_desc": "Efecto de resorte al cambiar el saldo y los totales"
   },
   "more": {
     "title": "Más",

--- a/web/src/i18n/locales/fr.json
+++ b/web/src/i18n/locales/fr.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Bilan hebdomadaire",
     "notify_weekly_summary_desc": "Récapitulatif du lundi sur les dépenses",
     "notify_goal_milestones": "Jalons d'objectifs",
-    "notify_goal_milestones_desc": "Alerte à 25%, 50%, 75%, 100% d'un objectif"
+    "notify_goal_milestones_desc": "Alerte à 25%, 50%, 75%, 100% d'un objectif",
+    "display": "Affichage",
+    "animate_numbers": "Animer les nombres",
+    "animate_numbers_desc": "Effet ressort lors des changements de solde et totaux"
   },
   "more": {
     "title": "Plus",

--- a/web/src/i18n/locales/id.json
+++ b/web/src/i18n/locales/id.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Ringkasan Mingguan",
     "notify_weekly_summary_desc": "Rekap hari Senin tentang pengeluaran minggu lalu",
     "notify_goal_milestones": "Pencapaian Tujuan",
-    "notify_goal_milestones_desc": "Peringatan di 25%, 50%, 75%, 100% tujuan"
+    "notify_goal_milestones_desc": "Peringatan di 25%, 50%, 75%, 100% tujuan",
+    "display": "Tampilan",
+    "animate_numbers": "Animasikan angka",
+    "animate_numbers_desc": "Efek pegas saat saldo dan total berubah"
   },
   "more": {
     "title": "Lainnya",

--- a/web/src/i18n/locales/it.json
+++ b/web/src/i18n/locales/it.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Riepilogo settimanale",
     "notify_weekly_summary_desc": "Riepilogo del lunedì sulle spese settimanali",
     "notify_goal_milestones": "Traguardi degli obiettivi",
-    "notify_goal_milestones_desc": "Avviso al 25%, 50%, 75%, 100% di un obiettivo"
+    "notify_goal_milestones_desc": "Avviso al 25%, 50%, 75%, 100% di un obiettivo",
+    "display": "Visualizzazione",
+    "animate_numbers": "Anima i numeri",
+    "animate_numbers_desc": "Effetto molla quando saldo e totali cambiano"
   },
   "more": {
     "title": "Altro",

--- a/web/src/i18n/locales/kk.json
+++ b/web/src/i18n/locales/kk.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Апталық қорытынды",
     "notify_weekly_summary_desc": "Дүйсенбідегі апталық шығыс шолуы",
     "notify_goal_milestones": "Мақсат жетістіктері",
-    "notify_goal_milestones_desc": "25%, 50%, 75%, 100% кезінде хабарландыру"
+    "notify_goal_milestones_desc": "25%, 50%, 75%, 100% кезінде хабарландыру",
+    "display": "Көрсету",
+    "animate_numbers": "Сандар анимациясы",
+    "animate_numbers_desc": "Баланс пен жиынтықтар өзгергендегі серіппе әсері"
   },
   "more": {
     "title": "Тағы",

--- a/web/src/i18n/locales/ko.json
+++ b/web/src/i18n/locales/ko.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "주간 요약",
     "notify_weekly_summary_desc": "월요일 주간 지출 요약",
     "notify_goal_milestones": "목표 달성",
-    "notify_goal_milestones_desc": "목표의 25%, 50%, 75%, 100% 시 알림"
+    "notify_goal_milestones_desc": "목표의 25%, 50%, 75%, 100% 시 알림",
+    "display": "표시",
+    "animate_numbers": "숫자 애니메이션",
+    "animate_numbers_desc": "잔액과 합계가 변할 때 스프링 효과"
   },
   "more": {
     "title": "더보기",

--- a/web/src/i18n/locales/ms.json
+++ b/web/src/i18n/locales/ms.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Ringkasan Mingguan",
     "notify_weekly_summary_desc": "Ringkasan hari Isnin tentang perbelanjaan minggu lalu",
     "notify_goal_milestones": "Pencapaian Matlamat",
-    "notify_goal_milestones_desc": "Amaran pada 25%, 50%, 75%, 100% matlamat"
+    "notify_goal_milestones_desc": "Amaran pada 25%, 50%, 75%, 100% matlamat",
+    "display": "Paparan",
+    "animate_numbers": "Animasikan nombor",
+    "animate_numbers_desc": "Kesan spring apabila baki dan jumlah berubah"
   },
   "more": {
     "title": "Lagi",

--- a/web/src/i18n/locales/nl.json
+++ b/web/src/i18n/locales/nl.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Wekelijkse samenvatting",
     "notify_weekly_summary_desc": "Maandag overzicht van de weekuitgaven",
     "notify_goal_milestones": "Doelmijlpalen",
-    "notify_goal_milestones_desc": "Melding bij 25%, 50%, 75%, 100% van een doel"
+    "notify_goal_milestones_desc": "Melding bij 25%, 50%, 75%, 100% van een doel",
+    "display": "Weergave",
+    "animate_numbers": "Getallen animeren",
+    "animate_numbers_desc": "Veereffect bij wijziging van saldo en totalen"
   },
   "more": {
     "title": "Meer",

--- a/web/src/i18n/locales/pt.json
+++ b/web/src/i18n/locales/pt.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Resumo semanal",
     "notify_weekly_summary_desc": "Resumo de segunda-feira sobre os gastos semanais",
     "notify_goal_milestones": "Marcos de objetivos",
-    "notify_goal_milestones_desc": "Alerta a 25%, 50%, 75%, 100% de um objetivo"
+    "notify_goal_milestones_desc": "Alerta a 25%, 50%, 75%, 100% de um objetivo",
+    "display": "Exibição",
+    "animate_numbers": "Animar números",
+    "animate_numbers_desc": "Efeito de mola ao alterar o saldo e os totais"
   },
   "more": {
     "title": "Mais",

--- a/web/src/i18n/locales/ru.json
+++ b/web/src/i18n/locales/ru.json
@@ -231,7 +231,10 @@
     "notify_weekly_summary": "Итог недели",
     "notify_weekly_summary_desc": "Понедельничный обзор расходов за неделю",
     "notify_goal_milestones": "Достижения целей",
-    "notify_goal_milestones_desc": "Оповещение при 25%, 50%, 75%, 100% цели"
+    "notify_goal_milestones_desc": "Оповещение при 25%, 50%, 75%, 100% цели",
+    "display": "Отображение",
+    "animate_numbers": "Анимация чисел",
+    "animate_numbers_desc": "Плавная анимация при изменении баланса и сумм"
   },
   "more": {
     "title": "Ещё",

--- a/web/src/i18n/locales/tr.json
+++ b/web/src/i18n/locales/tr.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Haftalık Özet",
     "notify_weekly_summary_desc": "Pazartesi haftalık harcama özeti",
     "notify_goal_milestones": "Hedef Dönüm Noktaları",
-    "notify_goal_milestones_desc": "%25, %50, %75, %100'de uyarı"
+    "notify_goal_milestones_desc": "%25, %50, %75, %100'de uyarı",
+    "display": "Görünüm",
+    "animate_numbers": "Sayıları canlandır",
+    "animate_numbers_desc": "Bakiye ve toplamlar değiştiğinde yay efekti"
   },
   "more": {
     "title": "Daha Fazla",

--- a/web/src/i18n/locales/uk.json
+++ b/web/src/i18n/locales/uk.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Підсумок тижня",
     "notify_weekly_summary_desc": "Понеділковий огляд витрат за тиждень",
     "notify_goal_milestones": "Досягнення цілей",
-    "notify_goal_milestones_desc": "Сповіщення при 25%, 50%, 75%, 100% цілі"
+    "notify_goal_milestones_desc": "Сповіщення при 25%, 50%, 75%, 100% цілі",
+    "display": "Відображення",
+    "animate_numbers": "Анімація чисел",
+    "animate_numbers_desc": "Плавна анімація при зміні балансу та сум"
   },
   "more": {
     "title": "Ще",

--- a/web/src/i18n/locales/uz.json
+++ b/web/src/i18n/locales/uz.json
@@ -224,7 +224,10 @@
     "notify_weekly_summary": "Haftalik xulosa",
     "notify_weekly_summary_desc": "Dushanba kuni haftalik xarajatlar sharhi",
     "notify_goal_milestones": "Maqsad yutuklar",
-    "notify_goal_milestones_desc": "Maqsadning 25%, 50%, 75%, 100%'ida ogohlantirish"
+    "notify_goal_milestones_desc": "Maqsadning 25%, 50%, 75%, 100%'ida ogohlantirish",
+    "display": "Koʻrsatish",
+    "animate_numbers": "Raqamlar animatsiyasi",
+    "animate_numbers_desc": "Balans va jamilar oʻzgargandagi prujina effekti"
   },
   "more": {
     "title": "Ko'proq",

--- a/web/src/shared/hooks/useAnimateNumbers.ts
+++ b/web/src/shared/hooks/useAnimateNumbers.ts
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+import { useReducedMotion } from 'framer-motion'
+
+export const ANIMATE_NUMBERS_KEY = 'app_animate_numbers'
+
+function getStored(): boolean | null {
+  try {
+    const v = localStorage.getItem(ANIMATE_NUMBERS_KEY)
+    if (v === 'true') return true
+    if (v === 'false') return false
+  } catch { /* ignore */ }
+  return null
+}
+
+export function setAnimateNumbersPreference(enabled: boolean): void {
+  try {
+    localStorage.setItem(ANIMATE_NUMBERS_KEY, String(enabled))
+  } catch { /* ignore */ }
+}
+
+/** Reactive hook: returns [enabled, setter].
+ *  Default: honor system `prefers-reduced-motion` when no explicit choice stored.
+ *  Explicit user choice always wins over OS preference.
+ */
+export function useAnimateNumbers(): [boolean, (b: boolean) => void] {
+  const systemReduced = useReducedMotion()
+  const [stored, setStored] = useState<boolean | null>(getStored)
+
+  const enabled = stored ?? !(systemReduced ?? false)
+
+  const set = (b: boolean) => {
+    setStored(b)
+    setAnimateNumbersPreference(b)
+  }
+
+  return [enabled, set]
+}


### PR DESCRIPTION
Closes #35

## Что сделано

- Новый хук `useAnimateNumbers` (`web/src/shared/hooks/useAnimateNumbers.ts`) с localStorage-ключом `app_animate_numbers` и уважением OS-настройки `prefers-reduced-motion` (через `useReducedMotion` из framer-motion). Явный выбор пользователя в Settings всегда перекрывает системный дефолт.
- Wrapper-разрез `AnimatedMoney` на dashboard (`SpringMoney` + `StaticMoney` + picker) — 3 call-site (hero-баланс, доход, расход).
- Wrapper-разрез `AnimatedNumber` на stats (`SpringNumber` + `StaticNumber` + picker) — 5 call-site (total, txCount, avgPerTx, categoriesCount, donut).
- Новая карточка «Display» в Settings между темой и нотификациями. UI повторяет стиль switch-кнопок из Notifications (haptic `selection()` на тогглe, иконка `Sparkle`).
- 3 i18n-ключа (`settings.display`, `settings.animate_numbers`, `settings.animate_numbers_desc`) во всех 17 локалях (en/ru — родные, остальные — переведены).

## Как проверить

- [ ] `cd web && npm run lint && npm run build` — оба зелёные.
- [ ] Default: localStorage пуст, OS reduce-motion OFF — toggle ON, баланс пружинит при смене счёта (dashboard) и при смене периода (stats).
- [ ] Toggle OFF в Settings → reload → суммы снапаются мгновенно везде; toggle снова ON → spring восстановлен.
- [ ] OS reduce-motion ON, localStorage пуст → toggle стартует OFF.
- [ ] OS reduce-motion ON, в Settings явно ON → spring работает (явный выбор перекрывает).
- [ ] Локализация: переключить язык на русский — подписи `Отображение / Анимация чисел / Плавная анимация...` появляются.
- [ ] Hooks-rule: тоггл OFF → ON в течение сессии не вызывает «Rendered more hooks than during the previous render» (wrapper-паттерн гарантирует).

## Out of scope

`PageTransition`, `AnimatePresence`, drag-spring у BottomSheet, donut-sweep, layout-анимации bento-карт — короткие decorative-анимации, не continuous counter. Не входят в скоуп issue.