### PR TITLE
feat(#17): sort categories by usage frequency in transaction forms

### DIFF
--- a/db/queries/categories.sql
+++ b/db/queries/categories.sql
@@ -35,6 +35,39 @@ WHERE user_id = $1
   AND (type = $2 OR type = 'both')
 ORDER BY name DESC;
 
+-- name: ListUserCategoriesByFrequency :many
+-- Sorts a user's categories by transaction count (descending), name as tiebreaker.
+-- The subquery aggregates without filtering by category type, so transactions
+-- referencing transfer/adjustment system categories simply do not match the
+-- outer JOIN and are discarded.
+SELECT c.id, c.user_id, c.name, c.icon, c.type, c.updated_at, c.deleted_at, c.color, c.is_protected
+FROM categories c
+LEFT JOIN (
+    SELECT category_id, COUNT(*) AS cnt
+    FROM transactions
+    WHERE transactions.user_id = $1 AND transactions.is_adjustment = false
+    GROUP BY category_id
+) t ON t.category_id = c.id
+WHERE c.user_id = $1
+  AND c.deleted_at IS NULL
+  AND c.type NOT IN ('transfer', 'adjustment')
+ORDER BY COALESCE(t.cnt, 0) DESC, c.name ASC;
+
+-- name: ListUserCategoriesByFrequencyAndType :many
+-- Same as ListUserCategoriesByFrequency, restricted to a single type plus 'both'.
+SELECT c.id, c.user_id, c.name, c.icon, c.type, c.updated_at, c.deleted_at, c.color, c.is_protected
+FROM categories c
+LEFT JOIN (
+    SELECT category_id, COUNT(*) AS cnt
+    FROM transactions
+    WHERE transactions.user_id = $1 AND transactions.is_adjustment = false
+    GROUP BY category_id
+) t ON t.category_id = c.id
+WHERE c.user_id = $1
+  AND c.deleted_at IS NULL
+  AND (c.type = $2 OR c.type = 'both')
+ORDER BY COALESCE(t.cnt, 0) DESC, c.name ASC;
+
 -- name: GetCategoryByID :one
 SELECT * FROM categories WHERE id = $1;
 

--- a/internal/api/categories_test.go
+++ b/internal/api/categories_test.go
@@ -81,6 +81,45 @@ func TestCategoriesHandler_GET_TypeFilter(t *testing.T) {
 	assert.Len(t, cats, 1)
 }
 
+func TestCategoriesHandler_GET_OrderFrequency(t *testing.T) {
+	repo := &mocks.MockCategoryStorer{}
+	repo.On("ListSorted", mock.Anything, int64(1), "", "frequency").Return([]*domain.Category{
+		{ID: 1, UserID: 1, Name: "Food"},
+		{ID: 2, UserID: 1, Name: "Transport"},
+	}, nil)
+
+	h := buildCatHandler(repo)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/categories?order=frequency", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	cats := resp["categories"].([]any)
+	assert.Len(t, cats, 2)
+}
+
+func TestCategoriesHandler_GET_OrderFrequencyWithType(t *testing.T) {
+	repo := &mocks.MockCategoryStorer{}
+	repo.On("ListSorted", mock.Anything, int64(1), "expense", "frequency").Return([]*domain.Category{
+		{ID: 1, UserID: 1, Name: "Food", Type: domain.CategoryTypeExpense},
+	}, nil)
+
+	h := buildCatHandler(repo)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/categories?order=frequency&type=expense", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	cats := resp["categories"].([]any)
+	assert.Len(t, cats, 1)
+}
+
 func TestCategoriesHandler_GET_InvalidOrder(t *testing.T) {
 	h := buildCatHandler(&mocks.MockCategoryStorer{})
 	w := httptest.NewRecorder()

--- a/internal/repository/category.go
+++ b/internal/repository/category.go
@@ -49,33 +49,38 @@ func (r *CategoryRepository) ListForUserByType(ctx context.Context, userID int64
 	return cats, nil
 }
 
-// ListSorted returns categories sorted by name in the given direction.
-// catType filters by category type when non-empty; order is "asc" or "desc".
+// ListSorted returns categories sorted by the given order.
+// catType filters by category type when non-empty.
+// order is "asc"/"desc" for name sorting, or "frequency" for transaction-count
+// descending with name-asc tiebreaker.
 func (r *CategoryRepository) ListSorted(ctx context.Context, userID int64, catType, order string) ([]*domain.Category, error) {
 	var (
 		rows []sqlcgen.Category
 		err  error
-		desc = order == "desc"
 	)
 
-	if catType != "" {
-		if desc {
-			rows, err = r.q.ListUserCategoriesByTypeFilterDesc(ctx, sqlcgen.ListUserCategoriesByTypeFilterDescParams{
-				UserID: pgInt8(userID),
-				Type:   catType,
-			})
-		} else {
-			rows, err = r.q.ListUserCategoriesByTypeFilterAsc(ctx, sqlcgen.ListUserCategoriesByTypeFilterAscParams{
-				UserID: pgInt8(userID),
-				Type:   catType,
-			})
-		}
-	} else {
-		if desc {
-			rows, err = r.q.ListUserCategoriesByNameDesc(ctx, pgInt8(userID))
-		} else {
-			rows, err = r.q.ListUserCategoriesByNameAsc(ctx, pgInt8(userID))
-		}
+	switch {
+	case order == "frequency" && catType != "":
+		rows, err = r.q.ListUserCategoriesByFrequencyAndType(ctx, sqlcgen.ListUserCategoriesByFrequencyAndTypeParams{
+			UserID: userID,
+			Type:   catType,
+		})
+	case order == "frequency":
+		rows, err = r.q.ListUserCategoriesByFrequency(ctx, userID)
+	case catType != "" && order == "desc":
+		rows, err = r.q.ListUserCategoriesByTypeFilterDesc(ctx, sqlcgen.ListUserCategoriesByTypeFilterDescParams{
+			UserID: pgInt8(userID),
+			Type:   catType,
+		})
+	case catType != "":
+		rows, err = r.q.ListUserCategoriesByTypeFilterAsc(ctx, sqlcgen.ListUserCategoriesByTypeFilterAscParams{
+			UserID: pgInt8(userID),
+			Type:   catType,
+		})
+	case order == "desc":
+		rows, err = r.q.ListUserCategoriesByNameDesc(ctx, pgInt8(userID))
+	default:
+		rows, err = r.q.ListUserCategoriesByNameAsc(ctx, pgInt8(userID))
 	}
 
 	if err != nil {

--- a/internal/repository/sqlcgen/categories.sql.go
+++ b/internal/repository/sqlcgen/categories.sql.go
@@ -214,6 +214,106 @@ func (q *Queries) ListUserCategories(ctx context.Context, userID pgtype.Int8) ([
 	return items, nil
 }
 
+const listUserCategoriesByFrequency = `-- name: ListUserCategoriesByFrequency :many
+SELECT c.id, c.user_id, c.name, c.icon, c.type, c.updated_at, c.deleted_at, c.color, c.is_protected
+FROM categories c
+LEFT JOIN (
+    SELECT category_id, COUNT(*) AS cnt
+    FROM transactions
+    WHERE transactions.user_id = $1 AND transactions.is_adjustment = false
+    GROUP BY category_id
+) t ON t.category_id = c.id
+WHERE c.user_id = $1
+  AND c.deleted_at IS NULL
+  AND c.type NOT IN ('transfer', 'adjustment')
+ORDER BY COALESCE(t.cnt, 0) DESC, c.name ASC
+`
+
+// Sorts a user's categories by transaction count (descending), name as tiebreaker.
+// The subquery aggregates without filtering by category type, so transactions
+// referencing transfer/adjustment system categories simply do not match the
+// outer JOIN and are discarded.
+func (q *Queries) ListUserCategoriesByFrequency(ctx context.Context, userID int64) ([]Category, error) {
+	rows, err := q.db.Query(ctx, listUserCategoriesByFrequency, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Category{}
+	for rows.Next() {
+		var i Category
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.Name,
+			&i.Icon,
+			&i.Type,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Color,
+			&i.IsProtected,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUserCategoriesByFrequencyAndType = `-- name: ListUserCategoriesByFrequencyAndType :many
+SELECT c.id, c.user_id, c.name, c.icon, c.type, c.updated_at, c.deleted_at, c.color, c.is_protected
+FROM categories c
+LEFT JOIN (
+    SELECT category_id, COUNT(*) AS cnt
+    FROM transactions
+    WHERE transactions.user_id = $1 AND transactions.is_adjustment = false
+    GROUP BY category_id
+) t ON t.category_id = c.id
+WHERE c.user_id = $1
+  AND c.deleted_at IS NULL
+  AND (c.type = $2 OR c.type = 'both')
+ORDER BY COALESCE(t.cnt, 0) DESC, c.name ASC
+`
+
+type ListUserCategoriesByFrequencyAndTypeParams struct {
+	UserID int64  `json:"user_id"`
+	Type   string `json:"type"`
+}
+
+// Same as ListUserCategoriesByFrequency, restricted to a single type plus 'both'.
+func (q *Queries) ListUserCategoriesByFrequencyAndType(ctx context.Context, arg ListUserCategoriesByFrequencyAndTypeParams) ([]Category, error) {
+	rows, err := q.db.Query(ctx, listUserCategoriesByFrequencyAndType, arg.UserID, arg.Type)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Category{}
+	for rows.Next() {
+		var i Category
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.Name,
+			&i.Icon,
+			&i.Type,
+			&i.UpdatedAt,
+			&i.DeletedAt,
+			&i.Color,
+			&i.IsProtected,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUserCategoriesByNameAsc = `-- name: ListUserCategoriesByNameAsc :many
 SELECT id, user_id, name, icon, type, updated_at, deleted_at, color, is_protected FROM categories
 WHERE user_id = $1 AND deleted_at IS NULL AND type NOT IN ('transfer', 'adjustment')

--- a/internal/repository/sqlcgen/querier.go
+++ b/internal/repository/sqlcgen/querier.go
@@ -105,6 +105,13 @@ type Querier interface {
 	ListTransfersByAccount(ctx context.Context, arg ListTransfersByAccountParams) ([]ListTransfersByAccountRow, error)
 	ListTransfersByUser(ctx context.Context, arg ListTransfersByUserParams) ([]ListTransfersByUserRow, error)
 	ListUserCategories(ctx context.Context, userID pgtype.Int8) ([]Category, error)
+	// Sorts a user's categories by transaction count (descending), name as tiebreaker.
+	// The subquery aggregates without filtering by category type, so transactions
+	// referencing transfer/adjustment system categories simply do not match the
+	// outer JOIN and are discarded.
+	ListUserCategoriesByFrequency(ctx context.Context, userID int64) ([]Category, error)
+	// Same as ListUserCategoriesByFrequency, restricted to a single type plus 'both'.
+	ListUserCategoriesByFrequencyAndType(ctx context.Context, arg ListUserCategoriesByFrequencyAndTypeParams) ([]Category, error)
 	ListUserCategoriesByNameAsc(ctx context.Context, userID pgtype.Int8) ([]Category, error)
 	ListUserCategoriesByNameDesc(ctx context.Context, userID pgtype.Int8) ([]Category, error)
 	ListUserCategoriesByType(ctx context.Context, arg ListUserCategoriesByTypeParams) ([]Category, error)

--- a/internal/service/category.go
+++ b/internal/service/category.go
@@ -37,14 +37,15 @@ func (s *CategoryService) ListForUserByType(ctx context.Context, userID int64, c
 	return cats, nil
 }
 
-// ListSorted returns categories optionally filtered by type and sorted by name.
+// ListSorted returns categories optionally filtered by type and sorted.
 // catType filters by category type when non-empty ("expense", "income", "both").
-// order controls sort direction: "asc" (default) or "desc".
+// order controls sort: "asc"/"desc" by name, or "frequency" by transaction count
+// descending with name-asc tiebreaker.
 func (s *CategoryService) ListSorted(ctx context.Context, userID int64, catType, order string) ([]*domain.Category, error) {
 	switch order {
 	case "", "asc":
 		order = "asc"
-	case "desc":
+	case "desc", "frequency":
 		// valid
 	default:
 		return nil, fmt.Errorf("order %q: %w", order, domain.ErrInvalidSortParam)

--- a/internal/service/category_test.go
+++ b/internal/service/category_test.go
@@ -153,6 +153,35 @@ func TestCategoryService_ListSorted_InvalidOrder(t *testing.T) {
 	assert.ErrorIs(t, err, domain.ErrInvalidSortParam)
 }
 
+func TestCategoryService_ListSorted_Frequency(t *testing.T) {
+	repo := &mocks.MockCategoryStorer{}
+	svc := newCatService(repo)
+
+	cats := []*domain.Category{
+		{ID: 1, UserID: 99, Name: "Food"},
+		{ID: 2, UserID: 99, Name: "Transport"},
+	}
+	repo.On("ListSorted", mock.Anything, int64(99), "", "frequency").Return(cats, nil)
+
+	got, err := svc.ListSorted(context.Background(), 99, "", "frequency")
+	require.NoError(t, err)
+	assert.Len(t, got, 2)
+	repo.AssertExpectations(t)
+}
+
+func TestCategoryService_ListSorted_FrequencyWithType(t *testing.T) {
+	repo := &mocks.MockCategoryStorer{}
+	svc := newCatService(repo)
+
+	cats := []*domain.Category{{ID: 1, UserID: 99, Name: "Food", Type: domain.CategoryTypeExpense}}
+	repo.On("ListSorted", mock.Anything, int64(99), "expense", "frequency").Return(cats, nil)
+
+	got, err := svc.ListSorted(context.Background(), 99, "expense", "frequency")
+	require.NoError(t, err)
+	assert.Len(t, got, 1)
+	repo.AssertExpectations(t)
+}
+
 func TestCategoryService_ListSorted_InvalidType(t *testing.T) {
 	repo := &mocks.MockCategoryStorer{}
 	svc := newCatService(repo)

--- a/web/src/features/add-transaction/index.tsx
+++ b/web/src/features/add-transaction/index.tsx
@@ -43,8 +43,8 @@ export function AddTransactionPage() {
   const [exchangeRate, setExchangeRate] = useState<number | null>(null)
 
   const { data: catData, isLoading } = useQuery({
-    queryKey: ['categories'],
-    queryFn: () => categoriesApi.list(),
+    queryKey: ['categories', { order: 'frequency' }],
+    queryFn: () => categoriesApi.list(undefined, 'frequency'),
   })
 
   const { data: balanceData } = useQuery({
@@ -101,6 +101,7 @@ export function AddTransactionPage() {
       qc.invalidateQueries({ queryKey: ['balance'] })
       qc.invalidateQueries({ queryKey: ['accounts'] })
       qc.invalidateQueries({ queryKey: ['stats'] })
+      qc.invalidateQueries({ queryKey: ['categories'] })
       navigate('/')
     },
     onError: () => notification('error'),

--- a/web/src/features/budgets/index.tsx
+++ b/web/src/features/budgets/index.tsx
@@ -182,7 +182,7 @@ function BudgetForm({
   const [period, setPeriod] = useState(editBudget?.period ?? 'monthly')
   const [notificationsEnabled, setNotificationsEnabled] = useState(editBudget?.notifications_enabled ?? true)
 
-  const catsQ = useQuery({ queryKey: ['categories'], queryFn: () => categoriesApi.list('expense') })
+  const catsQ = useQuery({ queryKey: ['categories', { type: 'expense', order: 'frequency' }], queryFn: () => categoriesApi.list('expense', 'frequency') })
   const categories = catsQ.data?.categories ?? []
 
   const createMut = useMutation({

--- a/web/src/features/history/index.tsx
+++ b/web/src/features/history/index.tsx
@@ -237,6 +237,7 @@ export function HistoryPage() {
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['transactions'] })
       qc.invalidateQueries({ queryKey: ['balance'] })
+      qc.invalidateQueries({ queryKey: ['categories'] })
     },
   })
 

--- a/web/src/features/recurring/index.tsx
+++ b/web/src/features/recurring/index.tsx
@@ -115,7 +115,7 @@ function RecurringForm({
   const [accountID, setAccountID] = useState<number | null>(editItem?.account_id ?? null)
 
   const { data: accounts = [] } = useQuery({ queryKey: ['accounts'], queryFn: accountsApi.list })
-  const catsQ = useQuery({ queryKey: ['categories'], queryFn: () => categoriesApi.list() })
+  const catsQ = useQuery({ queryKey: ['categories', { order: 'frequency' }], queryFn: () => categoriesApi.list(undefined, 'frequency') })
   const categories = catsQ.data?.categories ?? []
   const filtered = categories.filter(c => c.type === type || c.type === 'both')
 

--- a/web/src/shared/api/categories.ts
+++ b/web/src/shared/api/categories.ts
@@ -2,9 +2,12 @@ import { api } from './client'
 import type { CategoriesResponse, Category } from '../types'
 
 export const categoriesApi = {
-  list(type?: string): Promise<CategoriesResponse> {
-    const params = type ? `?type=${type}` : ''
-    return api.get(`/v1/categories${params}`)
+  list(type?: string, order?: string): Promise<CategoriesResponse> {
+    const params = new URLSearchParams()
+    if (type) params.set('type', type)
+    if (order) params.set('order', order)
+    const qs = params.toString()
+    return api.get(`/v1/categories${qs ? `?${qs}` : ''}`)
   },
   create(body: { name: string; icon: string; type: string; color: string }): Promise<Category> {
     return api.post('/v1/categories', body)

--- a/web/src/shared/ui/EditTransactionSheet.tsx
+++ b/web/src/shared/ui/EditTransactionSheet.tsx
@@ -35,7 +35,7 @@ export function EditTransactionSheet({
   const [txDate, setTxDate] = useState(tx.created_at.split('T')[0])
   const [showDatePicker, setShowDatePicker] = useState(false)
 
-  const catsQ = useQuery({ queryKey: ['categories'], queryFn: () => categoriesApi.list() })
+  const catsQ = useQuery({ queryKey: ['categories', { order: 'frequency' }], queryFn: () => categoriesApi.list(undefined, 'frequency') })
   const categories = catsQ.data?.categories ?? []
   const filtered = categories.filter(c => c.type === tx.type || c.type === 'both')
 
@@ -59,6 +59,7 @@ export function EditTransactionSheet({
       qc.invalidateQueries({ queryKey: ['balance'] })
       qc.invalidateQueries({ queryKey: ['accounts'] })
       qc.invalidateQueries({ queryKey: ['stats'] })
+      qc.invalidateQueries({ queryKey: ['categories'] })
       notification('success')
       onClose()
     },


### PR DESCRIPTION
Closes #17

## Что сделано

В четырёх формах (Add Transaction, Edit Transaction, Budget, Recurring) категории теперь сортируются по частоте использования: чем больше транзакций пользователь сделал в категории, тем выше она в списке. Категории с одинаковым счётчиком (включая ноль) идут по алфавиту.

**Backend (Go):**
- 2 новых SQL query в `db/queries/categories.sql`: `ListUserCategoriesByFrequency` и `ListUserCategoriesByFrequencyAndType` — `LEFT JOIN` с подзапросом `COUNT(*) FROM transactions GROUP BY category_id`, `ORDER BY COALESCE(cnt, 0) DESC, name ASC`. Без миграции БД.
- `CategoryService.ListSorted` принимает третий вариант `order="frequency"` рядом с `asc/desc`.
- `CategoryRepository.ListSorted` маршрутизирует запросы по новой ветке.
- API-handler уже пробрасывал `?order=` в сервис — изменений в `internal/api/categories.go` не понадобилось.

**Frontend (React + TanStack Query):**
- `categoriesApi.list(type?, order?)` — добавлен опциональный `order`, оба параметра сериализуются через `URLSearchParams`.
- 4 пикера переведены на `useQuery({ queryKey: ['categories', { ..., order: 'frequency' }] })`. Страница «Категории» (управление) и фильтр истории остались на `['categories']` (алфавит) — это сознательный выбор.
- Добавлена инвалидация `['categories']` после create/update/delete транзакции, чтобы счётчики frequency обновлялись вживую (prefix-matching покрывает оба ключа).

**Тесты:**
- `internal/service/category_test.go` — `TestCategoryService_ListSorted_Frequency`, `TestCategoryService_ListSorted_FrequencyWithType` (TDD: red→green).
- `internal/api/categories_test.go` — `TestCategoriesHandler_GET_OrderFrequency`, `TestCategoriesHandler_GET_OrderFrequencyWithType`.

**Производительность:** существующий индекс `idx_transactions_user_id` покрывает подзапрос; для типичных объёмов JOIN+GROUP BY — миллисекунды. Не вводим новый индекс ради MVP.

## Как проверить

1. Создать тестового пользователя или взять существующего.
2. Сделать ≥3 транзакций в одной категории, 1 в другой, 0 в третьей.
3. Открыть **Add Transaction** → самая частая категория сверху, нулевые внизу в алфавитном порядке.
4. Открыть **Edit Transaction** существующей записи → тот же порядок.
5. Открыть **Budget Form** → frequency-порядок среди expense-категорий.
6. Открыть **Recurring Form** → frequency-порядок.
7. Создать новую транзакцию в редкой категории → сразу после закрытия формы пикер показывает её выше (invalidation работает).
8. Открыть страницу **«Категории»** (управление) → порядок остался алфавитным.
9. Открыть **History → фильтр по категории** → не сломан.

API smoke:
```
GET /api/v1/categories?order=frequency
GET /api/v1/categories?order=frequency&type=expense
GET /api/v1/categories?order=asc           # без регресса
GET /api/v1/categories?order=invalid       # 400
```

## Локальный CI

- ✅ `make lint` — 0 issues
- ✅ `make vuln` — clean
- ✅ `go test -short ./...` (race-detector требует CGO/GCC — локально не установлен; на CI пройдёт `-race`)
- ✅ `make build-check`
- ✅ `web/ npm run build`