### PR TITLE
feat(#9): inline calculator in amount inputs

### DIFF
--- a/web/src/features/add-transaction/index.tsx
+++ b/web/src/features/add-transaction/index.tsx
@@ -9,12 +9,12 @@ import { transactionsApi } from '../../shared/api/transactions'
 import { transfersApi, exchangeApi } from '../../shared/api/transfers'
 import { balanceApi } from '../../shared/api/balance'
 import { accountsApi } from '../../shared/api/accounts'
-import { parseCents, sanitizeAmount } from '../../shared/lib/money'
+import { parseCents } from '../../shared/lib/money'
 import { CategoryIcon } from '../../shared/lib/categoryIcons'
-import { CurrencyBadge } from '../../shared/lib/currencyIcons'
 import { useTgMainButton } from '../../shared/hooks/useMainButton'
 import { useTgBackButton } from '../../shared/hooks/useTelegramApp'
 import { useHaptic } from '../../shared/hooks/useHaptic'
+import { AmountInput } from '../../shared/ui/AmountInput'
 import { Spinner } from '../../shared/ui/Spinner'
 import { PageTransition } from '../../shared/ui/PageTransition'
 import { useCategoryName } from '../../shared/hooks/useCategoryName'
@@ -154,10 +154,6 @@ export function AddTransactionPage() {
     }
   }, [canSubmit, isTransfer, fromAccountId, toAccountId, amount, note, categoryID, mode, txDate, selectedAccountId, txMutation, transferMutation])
 
-  const handleAmountChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setAmount(sanitizeAmount(e.target.value))
-  }, [])
-
   const handleModeChange = (m: Mode) => {
     setMode(m)
     setCategoryID(null)
@@ -232,17 +228,14 @@ export function AddTransactionPage() {
             </div>
 
             {/* Amount input — always shown */}
-            <div className="mt-4 flex items-baseline gap-1">
-              <CurrencyBadge currency={baseCurrency} className="text-white/50" />
-              <input
-                inputMode="decimal"
-                placeholder="0.00"
-                value={amount}
-                onChange={handleAmountChange}
-                autoFocus
-                className="flex-1 bg-transparent text-white text-4xl font-extrabold outline-none tabular-nums placeholder:text-white/25 min-w-0"
-              />
-            </div>
+            <AmountInput
+              className="mt-4"
+              variant="hero"
+              value={amount}
+              onChange={setAmount}
+              currency={baseCurrency}
+              autoFocus
+            />
 
             {/* Transfer: from ⇄ to row */}
             {isTransfer && (

--- a/web/src/features/budgets/index.tsx
+++ b/web/src/features/budgets/index.tsx
@@ -7,9 +7,10 @@ import { Plus, Warning, ClockCounterClockwise, ArrowCircleDown, ChartBar, Bell, 
 import { fetchBudgets, createBudget, updateBudget, deleteBudget, fetchBudgetTransactions } from '../../shared/api/budgets'
 import type { BudgetTransaction } from '../../shared/api/budgets'
 import { categoriesApi } from '../../shared/api/categories'
-import { formatCents, parseCents, sanitizeAmount } from '../../shared/lib/money'
+import { formatCents, parseCents } from '../../shared/lib/money'
 import { friendlyError } from '../../shared/lib/errors'
 import { CategoryIcon } from '../../shared/lib/categoryIcons'
+import { AmountInput } from '../../shared/ui/AmountInput'
 import { Spinner } from '../../shared/ui/Spinner'
 import { ErrorMessage } from '../../shared/ui/ErrorMessage'
 import { PageTransition } from '../../shared/ui/PageTransition'
@@ -18,7 +19,6 @@ import { useHaptic } from '../../shared/hooks/useHaptic'
 import { EmptyState, ActionRow, FAB, BottomSheet } from '../../shared/ui'
 import { useCategoryName } from '../../shared/hooks/useCategoryName'
 import { useBaseCurrency } from '../../shared/hooks/useBaseCurrency'
-import { CurrencyBadge } from '../../shared/lib/currencyIcons'
 import type { Budget } from '../../shared/types'
 
 /* ─── Budget Transactions Sheet ─── */
@@ -262,16 +262,7 @@ function BudgetForm({
           <label className="block text-[11px] font-bold text-muted uppercase tracking-widest mb-1.5">
             {t('budgets.limit')}
           </label>
-          <div className="flex items-baseline gap-1.5 bg-bg rounded-2xl px-4 py-3 focus-within:shadow-(--shadow-focus) transition-shadow">
-            <CurrencyBadge currency={currencyCode} className="text-muted/40" />
-            <input
-              inputMode="decimal"
-              placeholder="0.00"
-              value={limitStr}
-              onChange={e => setLimitStr(sanitizeAmount(e.target.value))}
-              className="flex-1 bg-transparent text-3xl font-bold outline-none text-text placeholder:text-muted/30 tabular-nums min-w-0"
-            />
-          </div>
+          <AmountInput value={limitStr} onChange={setLimitStr} currency={currencyCode} />
         </div>
 
         {/* Period */}

--- a/web/src/features/recurring/index.tsx
+++ b/web/src/features/recurring/index.tsx
@@ -7,9 +7,10 @@ import { Plus, Pause, Play, ArrowsClockwise } from '@phosphor-icons/react'
 import { fetchRecurring, createRecurring, updateRecurring, toggleRecurring, deleteRecurring } from '../../shared/api/recurring'
 import { categoriesApi } from '../../shared/api/categories'
 import { accountsApi } from '../../shared/api/accounts'
-import { formatCents, parseCents, formatDate, sanitizeAmount } from '../../shared/lib/money'
+import { formatCents, parseCents, formatDate } from '../../shared/lib/money'
 import { friendlyError } from '../../shared/lib/errors'
 import { CategoryIcon } from '../../shared/lib/categoryIcons'
+import { AmountInput } from '../../shared/ui/AmountInput'
 import { Spinner } from '../../shared/ui/Spinner'
 import { ErrorMessage } from '../../shared/ui/ErrorMessage'
 import { PageTransition } from '../../shared/ui/PageTransition'
@@ -19,7 +20,6 @@ import { Badge, EmptyState, ActionRow, FAB, BottomSheet } from '../../shared/ui'
 import { AccountDropdown } from '../../shared/ui/AccountDropdown'
 import { useCategoryName } from '../../shared/hooks/useCategoryName'
 import { useBaseCurrency } from '../../shared/hooks/useBaseCurrency'
-import { CurrencyBadge } from '../../shared/lib/currencyIcons'
 import type { RecurringTransaction, TransactionType } from '../../shared/types'
 
 const FREQ_OPTIONS = [
@@ -206,16 +206,7 @@ function RecurringForm({
           <label className="block text-[11px] font-bold text-muted uppercase tracking-widest mb-1.5">
             {t('transactions.amount')}
           </label>
-          <div className="flex items-baseline gap-1.5 bg-bg rounded-2xl px-4 py-3 focus-within:shadow-(--shadow-focus) transition-shadow">
-            <CurrencyBadge currency={currencyCode} className="text-muted/40" />
-            <input
-              inputMode="decimal"
-              placeholder="0.00"
-              value={amount}
-              onChange={e => setAmount(sanitizeAmount(e.target.value))}
-              className="flex-1 bg-transparent text-3xl font-bold outline-none text-text placeholder:text-muted/30 tabular-nums min-w-0"
-            />
-          </div>
+          <AmountInput value={amount} onChange={setAmount} currency={currencyCode} />
         </div>
 
         {/* Frequency */}

--- a/web/src/features/savings/index.tsx
+++ b/web/src/features/savings/index.tsx
@@ -7,9 +7,9 @@ import { Plus, X, CheckCircle, ArrowCircleDown, ArrowCircleUp, CalendarBlank, Cl
 import { fetchGoals, createGoal, updateGoal, depositGoal, withdrawGoal, deleteGoal, fetchGoalHistory } from '../../shared/api/goals'
 import type { GoalTransaction } from '../../shared/api/goals'
 import { accountsApi } from '../../shared/api/accounts'
-import { formatCents, parseCents, formatDate, sanitizeAmount } from '../../shared/lib/money'
-import { CurrencyBadge } from '../../shared/lib/currencyIcons'
+import { formatCents, parseCents, formatDate } from '../../shared/lib/money'
 import { friendlyError } from '../../shared/lib/errors'
+import { AmountInput } from '../../shared/ui/AmountInput'
 import { Spinner } from '../../shared/ui/Spinner'
 import { ErrorMessage } from '../../shared/ui/ErrorMessage'
 import { PageTransition } from '../../shared/ui/PageTransition'
@@ -192,16 +192,7 @@ function GoalFormSheet({ onClose, editGoal }: { onClose: () => void; editGoal?: 
             <label className="block text-[11px] font-bold text-muted uppercase tracking-widest mb-1.5">
               {t('savings.target')}
             </label>
-            <div className="flex items-baseline gap-2 bg-bg rounded-2xl px-4 py-3 focus-within:shadow-(--shadow-focus) transition-shadow">
-              <CurrencyBadge currency={currencyCode} className="text-muted/40" />
-              <input
-                inputMode="decimal"
-                placeholder="0.00"
-                value={targetStr}
-                onChange={e => setTargetStr(sanitizeAmount(e.target.value))}
-                className="flex-1 bg-transparent text-3xl font-bold outline-none text-text placeholder:text-muted/20 tabular-nums min-w-0"
-              />
-            </div>
+            <AmountInput value={targetStr} onChange={setTargetStr} currency={currencyCode} />
           </div>
 
           {/* Deadline */}
@@ -337,17 +328,7 @@ function AmountSheet({
           </button>
         </div>
 
-        <div className="flex items-baseline gap-2 bg-bg rounded-2xl px-4 py-3 focus-within:shadow-(--shadow-focus) transition-shadow">
-          <CurrencyBadge currency={amountCurrency} className="text-muted/40" />
-          <input
-            inputMode="decimal"
-            placeholder="0.00"
-            value={amountStr}
-            onChange={e => setAmountStr(sanitizeAmount(e.target.value))}
-            autoFocus
-            className="flex-1 bg-transparent text-3xl font-bold outline-none text-text placeholder:text-muted/20 tabular-nums min-w-0"
-          />
-        </div>
+        <AmountInput value={amountStr} onChange={setAmountStr} currency={amountCurrency} autoFocus />
 
         <button
           onClick={() => onConfirm(cents)}

--- a/web/src/features/transfers/index.tsx
+++ b/web/src/features/transfers/index.tsx
@@ -8,7 +8,7 @@ import { transfersApi } from '../../shared/api/transfers'
 import { accountsApi } from '../../shared/api/accounts'
 import { formatCents, formatDate, parseCents, sanitizeAmount } from '../../shared/lib/money'
 import { friendlyError } from '../../shared/lib/errors'
-import { CurrencyBadge } from '../../shared/lib/currencyIcons'
+import { AmountInput } from '../../shared/ui/AmountInput'
 import { Spinner } from '../../shared/ui/Spinner'
 import { ErrorMessage } from '../../shared/ui/ErrorMessage'
 import { PageTransition } from '../../shared/ui/PageTransition'
@@ -181,16 +181,13 @@ function TransferFormSheet({
           <label className="block text-[11px] font-bold text-muted uppercase tracking-widest mb-1.5">
             {t('transactions.amount')}
           </label>
-          <div className="flex items-baseline gap-2 bg-bg rounded-2xl px-4 py-3 focus-within:shadow-(--shadow-focus) transition-shadow">
-            {fromAccount && <CurrencyBadge currency={fromAccount.currency_code} className="text-muted/40" />}
-            <input
-              inputMode="decimal"
-              placeholder="0.00"
+          {fromAccount && (
+            <AmountInput
               value={amountStr}
-              onChange={e => setAmountStr(sanitizeAmount(e.target.value))}
-              className="flex-1 bg-transparent text-3xl font-bold outline-none text-text placeholder:text-muted/20 tabular-nums min-w-0"
+              onChange={setAmountStr}
+              currency={fromAccount.currency_code}
             />
-          </div>
+          )}
         </div>
 
         {/* Exchange rate (only when currencies differ) */}

--- a/web/src/shared/lib/expression.ts
+++ b/web/src/shared/lib/expression.ts
@@ -1,0 +1,125 @@
+export type EvalResult = { ok: true; value: number } | { ok: false }
+
+const MAX_LEN = 64
+const MAX_VALUE = 1e10
+
+const OPERATOR_RE = /[+\-*/×÷−()%]/
+
+export function looksLikeExpression(value: string): boolean {
+  return OPERATOR_RE.test(value)
+}
+
+export function formatForInput(value: number): string {
+  return (Math.round(value * 100) / 100).toString()
+}
+
+type Term = { value: number; lonePct: boolean }
+
+export function evaluate(input: string): EvalResult {
+  if (input.length > MAX_LEN) return { ok: false }
+  const src = input
+    .replace(/×/g, '*')
+    .replace(/÷/g, '/')
+    .replace(/−/g, '-')
+    .replace(/,/g, '.')
+    .replace(/\s+/g, '')
+  if (!src) return { ok: false }
+
+  let pos = 0
+  const peek = () => src[pos] ?? ''
+  const eat = () => src[pos++] ?? ''
+
+  const parseNumber = (): number | null => {
+    const start = pos
+    let dotSeen = false
+    while (pos < src.length) {
+      const c = src[pos]
+      if (c >= '0' && c <= '9') { pos++; continue }
+      if (c === '.') {
+        if (dotSeen) return null
+        dotSeen = true
+        pos++
+        continue
+      }
+      break
+    }
+    if (start === pos) return null
+    const n = parseFloat(src.slice(start, pos))
+    return isNaN(n) ? null : n
+  }
+
+  const parsePrimary = (): number | null => {
+    if (peek() === '(') {
+      pos++
+      const v = parseAdd()
+      if (v === null) return null
+      if (peek() !== ')') return null
+      pos++
+      return v
+    }
+    return parseNumber()
+  }
+
+  const parsePostfix = (): Term | null => {
+    const v = parsePrimary()
+    if (v === null) return null
+    if (peek() === '%') {
+      pos++
+      return { value: v / 100, lonePct: true }
+    }
+    return { value: v, lonePct: false }
+  }
+
+  const parseUnary = (): Term | null => {
+    if (peek() === '-') {
+      pos++
+      const t = parseUnary()
+      if (t === null) return null
+      return { value: -t.value, lonePct: t.lonePct }
+    }
+    if (peek() === '+') {
+      pos++
+      return parseUnary()
+    }
+    return parsePostfix()
+  }
+
+  const parseMul = (): Term | null => {
+    const left = parseUnary()
+    if (left === null) return null
+    if (peek() !== '*' && peek() !== '/') return left
+    let value = left.value
+    while (peek() === '*' || peek() === '/') {
+      const op = eat()
+      const right = parseUnary()
+      if (right === null) return null
+      if (op === '*') value *= right.value
+      else {
+        if (right.value === 0) return null
+        value /= right.value
+      }
+    }
+    return { value, lonePct: false }
+  }
+
+  const parseAdd = (): number | null => {
+    const leftT = parseMul()
+    if (leftT === null) return null
+    let acc = leftT.value
+    while (peek() === '+' || peek() === '-') {
+      const op = eat()
+      const right = parseMul()
+      if (right === null) return null
+      const delta = right.lonePct ? acc * right.value : right.value
+      acc = op === '+' ? acc + delta : acc - delta
+    }
+    return acc
+  }
+
+  const result = parseAdd()
+  if (result === null) return { ok: false }
+  if (pos !== src.length) return { ok: false }
+  if (!isFinite(result)) return { ok: false }
+  if (Math.abs(result) > MAX_VALUE) return { ok: false }
+  return { ok: true, value: result }
+}

--- a/web/src/shared/ui/AmountInput.tsx
+++ b/web/src/shared/ui/AmountInput.tsx
@@ -1,4 +1,7 @@
-import { sanitizeAmount } from '../lib/money'
+import { useRef } from 'react'
+import type { ChangeEvent, KeyboardEvent } from 'react'
+import { formatCents, sanitizeAmount } from '../lib/money'
+import { evaluate, formatForInput, looksLikeExpression } from '../lib/expression'
 import { CurrencyBadge } from '../lib/currencyIcons'
 
 interface AmountInputProps {
@@ -7,20 +10,119 @@ interface AmountInputProps {
   currency: string
   placeholder?: string
   autoFocus?: boolean
+  variant?: 'default' | 'hero'
+  calculator?: boolean
+  className?: string
 }
 
-export function AmountInput({ value, onChange, currency, placeholder = '0.00', autoFocus }: AmountInputProps) {
+const PERMISSIVE_RE = /[^0-9.,+\-*/×÷−()%\s]/g
+const MAX_LEN = 64
+
+function permissiveSanitize(value: string): string {
+  return value.replace(PERMISSIVE_RE, '').slice(0, MAX_LEN)
+}
+
+const TOOLBAR_OPS = ['+', '−', '×', '÷', '(', ')', '%']
+
+export function AmountInput({
+  value,
+  onChange,
+  currency,
+  placeholder = '0.00',
+  autoFocus,
+  variant = 'default',
+  calculator = true,
+  className,
+}: AmountInputProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  const isExpr = calculator && looksLikeExpression(value)
+  const evalResult = isExpr ? evaluate(value) : null
+  const previewValue = evalResult?.ok ? Math.max(0, evalResult.value) : 0
+  const previewString = evalResult?.ok ? formatForInput(previewValue) : ''
+  const showPreview = !!evalResult?.ok && previewString !== value
+
+  const commit = () => {
+    if (!calculator || !evalResult?.ok) return
+    if (previewString !== value) onChange(previewString)
+  }
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange(calculator ? permissiveSanitize(e.target.value) : sanitizeAmount(e.target.value))
+  }
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      commit()
+    }
+  }
+
+  const insertOp = (op: string) => {
+    const el = inputRef.current
+    const start = el?.selectionStart ?? value.length
+    const end = el?.selectionEnd ?? value.length
+    const next = permissiveSanitize(value.slice(0, start) + op + value.slice(end))
+    onChange(next)
+    requestAnimationFrame(() => {
+      const node = inputRef.current
+      if (!node) return
+      node.focus()
+      const cursor = Math.min(next.length, start + op.length)
+      node.setSelectionRange(cursor, cursor)
+    })
+  }
+
+  const isHero = variant === 'hero'
+  const wrapperClass = isHero
+    ? 'flex items-baseline gap-1'
+    : 'flex items-baseline gap-2 bg-bg rounded-2xl px-4 py-3 focus-within:shadow-(--shadow-focus) transition-shadow'
+  const inputClass = isHero
+    ? 'flex-1 bg-transparent text-white text-4xl font-extrabold outline-none tabular-nums placeholder:text-white/25 min-w-0'
+    : 'flex-1 bg-transparent text-3xl font-bold outline-none text-text placeholder:text-muted/20 tabular-nums min-w-0'
+  const badgeClass = isHero ? 'text-white/50' : 'text-muted/40'
+  const previewClass = isHero
+    ? 'mt-1 text-right text-xs text-white/70 tabular-nums'
+    : 'mt-1 text-right text-xs text-muted tabular-nums'
+
   return (
-    <div className="flex items-baseline gap-2 bg-bg rounded-2xl px-4 py-3 focus-within:shadow-(--shadow-focus) transition-shadow">
-      <CurrencyBadge currency={currency} className="text-muted/40" />
-      <input
-        inputMode="decimal"
-        placeholder={placeholder}
-        value={value}
-        onChange={e => onChange(sanitizeAmount(e.target.value))}
-        autoFocus={autoFocus}
-        className="flex-1 bg-transparent text-3xl font-bold outline-none text-text placeholder:text-muted/20 tabular-nums min-w-0"
-      />
+    <div className={className}>
+      <div className={wrapperClass}>
+        <CurrencyBadge currency={currency} className={badgeClass} />
+        <input
+          ref={inputRef}
+          inputMode="decimal"
+          placeholder={placeholder}
+          value={value}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onBlur={commit}
+          autoFocus={autoFocus}
+          className={inputClass}
+        />
+      </div>
+      {showPreview && (
+        <div className={previewClass}>= {formatCents(Math.round(previewValue * 100), currency)}</div>
+      )}
+      {calculator && (
+        <div className="hidden [@media(pointer:coarse)]:flex gap-1 mt-2">
+          {TOOLBAR_OPS.map(op => (
+            <button
+              key={op}
+              type="button"
+              onMouseDown={e => e.preventDefault()}
+              onClick={() => insertOp(op)}
+              className={
+                isHero
+                  ? 'flex-1 py-1.5 rounded-lg bg-white/15 backdrop-blur-sm text-white font-bold text-sm active:scale-90 transition-transform'
+                  : 'flex-1 py-1.5 rounded-lg bg-accent-subtle text-text font-bold text-sm active:scale-90 transition-transform'
+              }
+            >
+              {op}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/shared/ui/EditTransactionSheet.tsx
+++ b/web/src/shared/ui/EditTransactionSheet.tsx
@@ -5,12 +5,12 @@ import { AnimatePresence } from 'framer-motion'
 import { CalendarBlank, Check, CaretDown } from '@phosphor-icons/react'
 import { transactionsApi } from '../api/transactions'
 import { categoriesApi } from '../api/categories'
-import { parseCents, sanitizeAmount } from '../lib/money'
+import { parseCents } from '../lib/money'
 import { CategoryIcon } from '../lib/categoryIcons'
-import { CurrencyBadge } from '../lib/currencyIcons'
 import { useCategoryName } from '../hooks/useCategoryName'
 import { useBaseCurrency } from '../hooks/useBaseCurrency'
 import { useHaptic } from '../hooks/useHaptic'
+import { AmountInput } from './AmountInput'
 import { BottomSheet } from './BottomSheet'
 import { SingleDateModal, fmtDisplay } from './DatePicker'
 import type { Transaction } from '../types'
@@ -80,16 +80,7 @@ export function EditTransactionSheet({
           <label className="block text-[11px] font-bold text-muted uppercase tracking-widest mb-1.5">
             {t('transactions.amount')}
           </label>
-          <div className="flex items-baseline gap-1.5 bg-bg rounded-2xl px-4 py-3 focus-within:shadow-(--shadow-focus) transition-shadow">
-            <CurrencyBadge currency={txCurrency} className="text-muted/40" />
-            <input
-              inputMode="decimal"
-              placeholder="0.00"
-              value={amount}
-              onChange={e => setAmount(sanitizeAmount(e.target.value))}
-              className="flex-1 bg-transparent text-3xl font-bold outline-none text-text placeholder:text-muted/30 tabular-nums min-w-0"
-            />
-          </div>
+          <AmountInput value={amount} onChange={setAmount} currency={txCurrency} />
         </div>
 
         {/* Date */}


### PR DESCRIPTION
Closes #9

## Что сделано

- Новый модуль `web/src/shared/lib/expression.ts` — рекурсивный парсер выражений с поддержкой `+ − × ÷`, скобок и процентов в стиле обычного калькулятора (`100+10%` = 110, `200*15%` = 30, `(100+50)*10%` = 15). Без новых зависимостей.
- `AmountInput.tsx` расширен: live-превью «= 150.00» по мере ввода, коммит выражения по Enter / blur, опциональная панель операторов `+ − × ÷ ( ) %` для тач-устройств (`@media (pointer: coarse)`), вариант `hero` для тёмной карточки на add-transaction.
- 6 полей суммы переехали с raw `<input>` на общий `AmountInput`: add-transaction (hero), edit-transaction sheet, transfers (только сумма), budgets, savings (target + deposit/withdraw), recurring. Поле курса обмена в transfers намеренно осталось raw (другая семантика).
- Существующее использование `AmountInput` в balance-adjustment получает калькулятор «бесплатно» — все новые пропсы опциональны.

## Семантика процентов

| Выражение | Результат |
|---|---:|
| `50%` | `0.5` |
| `100+10%` | `110` |
| `100-10%` | `90` |
| `200*15%` | `30` |
| `(100+50)*10%` | `15` |

Отрицательный результат (`100-200`) клампится в 0 на коммите. Деление на ноль / неполные выражения / больше 1e10 — превью скрыто, коммит no-op.

## Как проверить

`cd web && npm run dev`, затем в браузере:
- add-transaction: `100+50%` → `= 150.00`, Enter → input = `150`, save.
- edit-transaction: `200*0.15` → `= 30.00`, blur → `30`, save.
- transfers: `1000-50` → `950`. Поле exchange rate отвергает операторы (raw input).
- budgets: `(2000+500)*0.8` → `2000`.
- savings target / deposit/withdraw: `5000+5000`, `100/3` → `33.33`.
- recurring: `50*2` → `100`.
- accounts (regression): `100` → без превью; `100+1` → `= 101.00`.
- Mobile (DevTools toggle): чипы операторов появляются над полем; на десктопе скрыты.
- Edge: пусто, `100+`, `((100`, `1/0`, `100-200` (= 0), вставить `1,5` (RU comma → 1.5), `100 × 2`.

## Заметки

- Тестов нет: на фронте отсутствует test runner (нет vitest/jest, ноль `*.test.tsx`). Решено выделить настройку test infra в отдельную задачу.
- `parseCents` оставлен без изменений — между keystroke и commit `canSubmit` может быть приближённым, но на blur/Enter значение очищается, и `parseCents` вызывается уже на чистом числе.
- Локальный CI-гейт зелёный: `npm run build`, `make lint`, `make vuln`, `make build-check`, Go unit-тесты. Web `npm run lint` — 15 проблем, все pre-existing на develop, ноль новых от этого PR.