### PR TITLE
test(#42): test coverage foundation + critical gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,6 @@ jobs:
         working-directory: web
         run: npm ci
 
-      - name: Lint Mini App
-        working-directory: web
-        run: npm run lint
-
       - name: Run Mini App tests with coverage
         working-directory: web
         run: npm run test:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,20 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Run unit tests
+      - name: Run unit tests with coverage
         env:
           BOT_TOKEN: test_token_placeholder
           LOG_LEVEL: warn
           MIGRATIONS_DIR: db/migrations
-        run: go test -v -race -short -timeout 60s ./...
+        run: go test -v -race -short -timeout 60s -coverprofile=coverage.out ./...
+
+      - name: Upload backend coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: coverage.out
+          retention-days: 14
 
   web-build:
     runs-on: ubuntu-latest
@@ -97,9 +105,25 @@ jobs:
         working-directory: web
         run: npm ci
 
+      - name: Lint Mini App
+        working-directory: web
+        run: npm run lint
+
+      - name: Run Mini App tests with coverage
+        working-directory: web
+        run: npm run test:coverage
+
       - name: Build Mini App
         working-directory: web
         run: npm run build
+
+      - name: Upload web coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-coverage
+          path: web/coverage
+          retention-days: 14
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ DATABASE_URL := $(shell grep -v '^\#' .env | grep '^DATABASE_URL=' | cut -d'=' -
 GOOSE      := $(GOOSE_BIN) -dir db/migrations postgres "$(DATABASE_URL)"
 SQLC       := cd db && sqlc generate
 
-.PHONY: help up down migrate migrate-down migrate-status sqlc build build-api build-check run run-api web-dev web-build test test-unit test-integration lint vet vuln tidy clean smoke-test rollback backup backup-status
+.PHONY: help up down migrate migrate-down migrate-status sqlc build build-api build-check run run-api web-dev web-build web-test test test-unit test-integration test-cover lint vet vuln tidy clean smoke-test rollback backup backup-status
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
@@ -56,6 +56,9 @@ web-dev: ## Start Mini App dev server (proxies /api → localhost:8080)
 web-build: ## Build Mini App for production into web/dist/
 	cd web && npm run build
 
+web-test: ## Run Mini App test suite (vitest)
+	cd web && npm run test
+
 test: ## Run all tests (unit + integration)
 	go test -v -race -timeout 120s -p 2 ./...
 
@@ -64,6 +67,10 @@ test-unit: ## Run unit tests only (skips integration tests)
 
 test-integration: ## Run integration tests only (requires DATABASE_URL and REDIS_URL)
 	go test -v -race -tags integration -timeout 120s -p 2 ./...
+
+test-cover: ## Run unit tests with coverage and print per-package summary
+	go test -race -short -timeout 60s -coverprofile=coverage.out ./...
+	go tool cover -func=coverage.out
 
 lint: ## Run golangci-lint
 	golangci-lint run ./...

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ make build         # Build binary to bin/bot
 make run           # Run bot locally
 make test          # Run all tests (unit + integration)
 make test-unit     # Run only unit tests (no Docker needed)
+make test-cover    # Run unit tests with coverage and per-package summary
+make web-test      # Run Mini App test suite (vitest)
 make lint          # Run golangci-lint
 make tidy          # go mod tidy
 make down          # Stop Docker services
@@ -169,16 +171,38 @@ Required GitHub repository secrets:
 ## Testing
 
 ```bash
-# Unit tests (no external dependencies)
-make test-unit
+# Backend
+make test-unit         # unit tests (no external dependencies)
+make test-cover        # unit tests + coverage profile (coverage.out)
+make test-integration  # integration tests (requires DATABASE_URL + REDIS_URL)
+make test              # everything (unit + integration)
 
-# All tests including integration (requires Docker)
-make test
+# Frontend (Mini App)
+cd web && npm run test            # one-shot vitest run
+cd web && npm run test:watch      # watch mode
+cd web && npm run test:coverage   # vitest + v8 coverage report into web/coverage/
+make web-test                     # shorthand for `cd web && npm run test`
 ```
 
-Integration tests use [testcontainers-go](https://golang.testcontainers.org/) to spin up real Postgres and Redis containers. They are tagged with `//go:build integration` and run via `go test -tags=integration ./...` in CI.
+Integration tests are tagged with `//go:build integration` and require a running PostgreSQL + Redis. CI provisions both via service containers; locally use `make up` to start them.
 
-Unit tests for the FSM store use [miniredis](https://github.com/alicebob/miniredis) — an in-memory Redis server — for fast, dependency-free testing.
+Frontend tests use [Vitest](https://vitest.dev/) + [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro/) with a jsdom environment. The shared setup lives in `web/src/test/`:
+
+- `setup.ts` — global mocks (`window.Telegram`, `matchMedia`, `@tma.js/sdk-react`, `framer-motion`).
+- `render.tsx` — `renderWithProviders` helper that wires `QueryClientProvider`, `MemoryRouter`, and an in-memory i18next instance.
+
+### Local CI gate (run before opening a PR)
+
+In strict order — stop on the first failure:
+
+```bash
+make lint
+make vuln
+make test-unit
+make build-check
+make test-cover
+cd web && npm ci && npm run lint && npm run build && npm run test:coverage
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ make vuln
 make test-unit
 make build-check
 make test-cover
-cd web && npm ci && npm run lint && npm run build && npm run test:coverage
+cd web && npm ci && npm run build && npm run test:coverage
 ```
 
 ## License

--- a/internal/api/adjustment_test.go
+++ b/internal/api/adjustment_test.go
@@ -1,0 +1,110 @@
+package api_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/api"
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+// fakeAdjustmentApplier is a testify mock for the unexported adjustmentApplier
+// interface, exposed via api.AdjustmentApplier.
+type fakeAdjustmentApplier struct {
+	mock.Mock
+}
+
+func (f *fakeAdjustmentApplier) Apply(ctx context.Context, userID, accountID, deltaCents int64, note string) (*domain.Transaction, error) {
+	args := f.Called(ctx, userID, accountID, deltaCents, note)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Transaction), args.Error(1)
+}
+
+func newAdjustmentRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/accounts/1/adjust", bytes.NewBufferString(body))
+	return r.WithContext(api.WithUserID(r.Context(), 1))
+}
+
+func TestAdjustAccountHandler_POST_Applies_PositiveDelta(t *testing.T) {
+	applier := &fakeAdjustmentApplier{}
+	applier.On("Apply", mock.Anything, int64(1), int64(7), int64(500), "").
+		Return(&domain.Transaction{ID: 100, AmountCents: 500, AccountID: 7, Type: domain.TransactionTypeIncome, IsAdjustment: true}, nil)
+
+	h := api.AdjustAccountHandlerForTest(applier, testutil.TestLogger(), 7)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAdjustmentRequest(t, `{"delta_cents":500}`))
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	applier.AssertExpectations(t)
+}
+
+func TestAdjustAccountHandler_POST_Applies_NegativeDelta(t *testing.T) {
+	applier := &fakeAdjustmentApplier{}
+	applier.On("Apply", mock.Anything, int64(1), int64(7), int64(-300), "correction").
+		Return(&domain.Transaction{ID: 101, AmountCents: 300, AccountID: 7, Type: domain.TransactionTypeExpense, IsAdjustment: true}, nil)
+
+	h := api.AdjustAccountHandlerForTest(applier, testutil.TestLogger(), 7)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAdjustmentRequest(t, `{"delta_cents":-300,"note":"correction"}`))
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	applier.AssertExpectations(t)
+}
+
+func TestAdjustAccountHandler_POST_400_OnInvalidJSON(t *testing.T) {
+	applier := &fakeAdjustmentApplier{}
+	h := api.AdjustAccountHandlerForTest(applier, testutil.TestLogger(), 7)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAdjustmentRequest(t, `{not-json}`))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	applier.AssertNotCalled(t, "Apply", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestAdjustAccountHandler_POST_400_OnZeroDelta(t *testing.T) {
+	applier := &fakeAdjustmentApplier{}
+	h := api.AdjustAccountHandlerForTest(applier, testutil.TestLogger(), 7)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAdjustmentRequest(t, `{"delta_cents":0}`))
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	applier.AssertNotCalled(t, "Apply", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestAdjustAccountHandler_NonPOST_Returns405(t *testing.T) {
+	applier := &fakeAdjustmentApplier{}
+	h := api.AdjustAccountHandlerForTest(applier, testutil.TestLogger(), 7)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/accounts/1/adjust", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestAdjustAccountHandler_PropagatesServiceError(t *testing.T) {
+	applier := &fakeAdjustmentApplier{}
+	applier.On("Apply", mock.Anything, int64(1), int64(7), int64(500), "").
+		Return(nil, errors.New("db down"))
+
+	h := api.AdjustAccountHandlerForTest(applier, testutil.TestLogger(), 7)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAdjustmentRequest(t, `{"delta_cents":500}`))
+
+	assert.GreaterOrEqual(t, w.Code, 400, "service error should map to a 4xx/5xx response")
+}

--- a/internal/api/balance_test.go
+++ b/internal/api/balance_test.go
@@ -1,0 +1,114 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/api"
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/service"
+	"github.com/horexdev/money-tracker/internal/testutil"
+	"github.com/horexdev/money-tracker/internal/testutil/mocks"
+)
+
+func buildBalanceHandler(
+	txRepo *mocks.MockTransactionStorer,
+	userRepo *mocks.MockUserStorer,
+	accountRepo *mocks.MockAccountStorer,
+) http.HandlerFunc {
+	log := testutil.TestLogger()
+	userSvc := service.NewUserService(userRepo, log)
+	accountSvc := service.NewAccountService(accountRepo, nil, log)
+	// exchangeSvc is nil — only used when user.DisplayCurrencies is non-empty.
+	return api.BalanceHandlerForTest(txRepo, userSvc, accountSvc, nil, log)
+}
+
+func TestBalanceHandler_GET_AggregatesByCurrency(t *testing.T) {
+	txRepo := &mocks.MockTransactionStorer{}
+	txRepo.On("GetBalanceByCurrency", mock.Anything, int64(1)).Return([]domain.BalanceByCurrency{
+		{CurrencyCode: "USD", IncomeCents: 100000, ExpenseCents: 30000},
+		{CurrencyCode: "EUR", IncomeCents: 50000, ExpenseCents: 20000},
+	}, nil)
+	txRepo.On("GetTotalInBaseCurrency", mock.Anything, int64(1), "USD").Return(int64(70000), nil)
+
+	userRepo := &mocks.MockUserStorer{}
+	userRepo.On("GetByID", mock.Anything, int64(1)).Return(&domain.User{ID: 1, Language: "en", DisplayCurrencies: nil}, nil)
+
+	accountRepo := &mocks.MockAccountStorer{}
+	accountRepo.On("GetDefault", mock.Anything, int64(1)).Return(&domain.Account{ID: 1, CurrencyCode: "USD", IsDefault: true}, nil)
+
+	h := buildBalanceHandler(txRepo, userRepo, accountRepo)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/balance", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+
+	h.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	byCurrency := resp["by_currency"].([]any)
+	require.Len(t, byCurrency, 2)
+	assert.Equal(t, float64(70000), resp["total_in_base_cents"])
+}
+
+func TestBalanceHandler_GET_FiltersByAccountID(t *testing.T) {
+	txRepo := &mocks.MockTransactionStorer{}
+	txRepo.On("GetBalanceByCurrencyAndAccount", mock.Anything, int64(1), int64(7)).Return([]domain.BalanceByCurrency{
+		{CurrencyCode: "USD", IncomeCents: 1000, ExpenseCents: 500},
+	}, nil)
+	txRepo.On("GetTotalInBaseCurrency", mock.Anything, int64(1), "USD").Return(int64(500), nil)
+
+	userRepo := &mocks.MockUserStorer{}
+	userRepo.On("GetByID", mock.Anything, int64(1)).Return(&domain.User{ID: 1, Language: "en"}, nil)
+
+	accountRepo := &mocks.MockAccountStorer{}
+	accountRepo.On("GetDefault", mock.Anything, int64(1)).Return(&domain.Account{ID: 1, CurrencyCode: "USD"}, nil)
+
+	h := buildBalanceHandler(txRepo, userRepo, accountRepo)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/balance?account_id=7", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+
+	h.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+	txRepo.AssertCalled(t, "GetBalanceByCurrencyAndAccount", mock.Anything, int64(1), int64(7))
+	txRepo.AssertNotCalled(t, "GetBalanceByCurrency", mock.Anything, mock.Anything)
+}
+
+func TestBalanceHandler_NonGET_Returns405(t *testing.T) {
+	h := buildBalanceHandler(&mocks.MockTransactionStorer{}, &mocks.MockUserStorer{}, &mocks.MockAccountStorer{})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/balance", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+
+	h.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestBalanceHandler_FallsBackToUSD_WhenNoDefaultAccount(t *testing.T) {
+	txRepo := &mocks.MockTransactionStorer{}
+	txRepo.On("GetBalanceByCurrency", mock.Anything, int64(1)).Return([]domain.BalanceByCurrency{}, nil)
+	txRepo.On("GetTotalInBaseCurrency", mock.Anything, int64(1), "USD").Return(int64(0), nil)
+
+	userRepo := &mocks.MockUserStorer{}
+	userRepo.On("GetByID", mock.Anything, int64(1)).Return(&domain.User{ID: 1, Language: "en"}, nil)
+
+	accountRepo := &mocks.MockAccountStorer{}
+	accountRepo.On("GetDefault", mock.Anything, int64(1)).Return(nil, domain.ErrAccountNotFound)
+
+	h := buildBalanceHandler(txRepo, userRepo, accountRepo)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/balance", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+
+	h.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+	txRepo.AssertCalled(t, "GetTotalInBaseCurrency", mock.Anything, int64(1), "USD")
+}

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -98,6 +98,30 @@ func AdminUsersHandlerForTest(adminSvc *service.AdminService, log *slog.Logger) 
 	return adminUsersHandler(adminSvc, log)
 }
 
+// BalanceFetcher is the exported alias for the unexported balanceFetcher
+// interface, allowing api_test handlers to inject mock implementations.
+type BalanceFetcher = balanceFetcher
+
+// BalanceHandlerForTest exposes balanceHandler for testing. exchangeSvc may be
+// nil if the user's DisplayCurrencies is empty.
+func BalanceHandlerForTest(txSvc BalanceFetcher, userSvc *service.UserService, accountSvc *service.AccountService, exchangeSvc *service.ExchangeService, log *slog.Logger) http.HandlerFunc {
+	return balanceHandler(txSvc, userSvc, accountSvc, exchangeSvc, log)
+}
+
+// StatsHandlerForTest exposes statsHandler for testing.
+func StatsHandlerForTest(statsSvc *service.StatsService, log *slog.Logger) http.HandlerFunc {
+	return statsHandler(statsSvc, log)
+}
+
+// AdjustmentApplier is the exported alias for the unexported adjustmentApplier
+// interface used by adjustAccountHandler.
+type AdjustmentApplier = adjustmentApplier
+
+// AdjustAccountHandlerForTest exposes adjustAccountHandler for testing.
+func AdjustAccountHandlerForTest(svc AdjustmentApplier, log *slog.Logger, accountID int64) http.HandlerFunc {
+	return adjustAccountHandler(svc, log, accountID)
+}
+
 // TelegramUserForTest constructs a TelegramUser for use in tests.
 func TelegramUserForTest(id int64, firstName, langCode string) TelegramUser {
 	return TelegramUser{ID: id, FirstName: firstName, LanguageCode: langCode}

--- a/internal/api/stats_test.go
+++ b/internal/api/stats_test.go
@@ -1,0 +1,118 @@
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/api"
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/service"
+	"github.com/horexdev/money-tracker/internal/testutil"
+	"github.com/horexdev/money-tracker/internal/testutil/mocks"
+)
+
+func buildStatsHandler(txRepo *mocks.MockTransactionStorer) http.HandlerFunc {
+	log := testutil.TestLogger()
+	statsSvc := service.NewStatsService(txRepo, log)
+	return api.StatsHandlerForTest(statsSvc, log)
+}
+
+func TestStatsHandler_GET_DefaultPeriodIsMonth(t *testing.T) {
+	txRepo := &mocks.MockTransactionStorer{}
+	txRepo.On("StatsByCategory", mock.Anything, int64(1), mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return([]domain.CategoryStat{
+			{CategoryName: "Food", Type: domain.TransactionTypeExpense, TotalCents: 1500, TxCount: 3, CurrencyCode: "USD"},
+		}, nil)
+
+	h := buildStatsHandler(txRepo)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/stats", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+
+	h.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "month", resp["period"])
+	assert.Len(t, resp["items"].([]any), 1)
+}
+
+func TestStatsHandler_GET_AcceptsCustomDateRange(t *testing.T) {
+	txRepo := &mocks.MockTransactionStorer{}
+	txRepo.On("StatsByCategory", mock.Anything, int64(1), mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return([]domain.CategoryStat{}, nil).
+		Run(func(args mock.Arguments) {
+			from := args.Get(2).(time.Time)
+			to := args.Get(3).(time.Time)
+			// from is the parsed "2026-04-01"; to is the day-after parsed "2026-04-30"
+			require.Equal(t, "2026-04-01", from.Format("2006-01-02"))
+			require.Equal(t, "2026-05-01", to.Format("2006-01-02"))
+		})
+
+	h := buildStatsHandler(txRepo)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/stats?from=2026-04-01&to=2026-04-30", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+
+	h.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Equal(t, "custom", resp["period"])
+}
+
+func TestStatsHandler_GET_400OnInvalidFromDate(t *testing.T) {
+	h := buildStatsHandler(&mocks.MockTransactionStorer{})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/stats?from=not-a-date&to=2026-04-30", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+
+	h.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestStatsHandler_GET_400OnInvalidToDate(t *testing.T) {
+	h := buildStatsHandler(&mocks.MockTransactionStorer{})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/stats?from=2026-04-01&to=invalid", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+
+	h.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestStatsHandler_GET_RoutesToAccountVariantWhenAccountIDProvided(t *testing.T) {
+	txRepo := &mocks.MockTransactionStorer{}
+	txRepo.On("StatsByCategoryAndAccount", mock.Anything, int64(1), int64(7),
+		mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return([]domain.CategoryStat{}, nil)
+
+	h := buildStatsHandler(txRepo)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/stats?period=month&account_id=7", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+
+	h.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusOK, w.Code)
+	txRepo.AssertCalled(t, "StatsByCategoryAndAccount", mock.Anything, int64(1), int64(7),
+		mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time"))
+}
+
+func TestStatsHandler_NonGET_Returns405(t *testing.T) {
+	h := buildStatsHandler(&mocks.MockTransactionStorer{})
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/stats", nil)
+	r = r.WithContext(api.WithUserID(r.Context(), 1))
+
+	h.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}

--- a/internal/domain/account_test.go
+++ b/internal/domain/account_test.go
@@ -1,0 +1,25 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+)
+
+// TestAccountType_StringValues guards against accidental edits to the AccountType
+// constants. The string values are part of the database enum (account_type) and
+// must match exactly — a mismatch would silently break inserts.
+func TestAccountType_StringValues(t *testing.T) {
+	cases := map[domain.AccountType]string{
+		domain.AccountTypeChecking: "checking",
+		domain.AccountTypeSavings:  "savings",
+		domain.AccountTypeCash:     "cash",
+		domain.AccountTypeCredit:   "credit",
+		domain.AccountTypeCrypto:   "crypto",
+	}
+	for got, want := range cases {
+		assert.Equal(t, want, string(got), "AccountType %q must serialise as %q", got, want)
+	}
+}

--- a/internal/domain/currency_test.go
+++ b/internal/domain/currency_test.go
@@ -1,0 +1,68 @@
+package domain_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+)
+
+func TestValidCurrency(t *testing.T) {
+	cases := []struct {
+		code string
+		want bool
+	}{
+		{"USD", true},
+		{"EUR", true},
+		{"GBP", true},
+		{"usd", true},
+		{"  USD  ", false}, // ToUpper only — does not trim
+		{"XYZ", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.code, func(t *testing.T) {
+			assert.Equal(t, c.want, domain.ValidCurrency(c.code))
+		})
+	}
+}
+
+func TestSearchCurrencies_EmptyQueryReturnsNil(t *testing.T) {
+	assert.Nil(t, domain.SearchCurrencies(""))
+}
+
+func TestSearchCurrencies_CodePrefixMatch(t *testing.T) {
+	results := domain.SearchCurrencies("USD")
+	require.NotEmpty(t, results)
+	assert.Equal(t, "USD", results[0].Code, "exact code prefix must rank first")
+}
+
+func TestSearchCurrencies_CapsAtFiveResults(t *testing.T) {
+	results := domain.SearchCurrencies("E")
+	assert.LessOrEqual(t, len(results), 5)
+}
+
+func TestSearchCurrencies_NameContainsMatch(t *testing.T) {
+	results := domain.SearchCurrencies("Dollar")
+	require.NotEmpty(t, results)
+	found := false
+	for _, c := range results {
+		if strings.Contains(strings.ToLower(c.Name), "dollar") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "results must contain at least one currency with 'dollar' in its name")
+}
+
+func TestSearchCurrencies_NoDuplicatesBetweenPasses(t *testing.T) {
+	results := domain.SearchCurrencies("US")
+	seen := make(map[string]bool)
+	for _, c := range results {
+		assert.Falsef(t, seen[c.Code], "duplicate currency in results: %s", c.Code)
+		seen[c.Code] = true
+	}
+}

--- a/internal/domain/transaction_test.go
+++ b/internal/domain/transaction_test.go
@@ -1,0 +1,24 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+)
+
+// TestTransactionType_StringValues guards the TransactionType constants against
+// accidental edits — the database transaction_type enum has 'expense'/'income'.
+func TestTransactionType_StringValues(t *testing.T) {
+	assert.Equal(t, "expense", string(domain.TransactionTypeExpense))
+	assert.Equal(t, "income", string(domain.TransactionTypeIncome))
+}
+
+func TestTransaction_DefaultValues(t *testing.T) {
+	tx := &domain.Transaction{}
+	assert.Zero(t, tx.ID)
+	assert.Zero(t, tx.AmountCents)
+	assert.False(t, tx.IsAdjustment, "adjustments must be opt-in via the IsAdjustment flag")
+	assert.Empty(t, string(tx.Type), "Type defaults to empty until explicitly set")
+}

--- a/internal/domain/transfer_test.go
+++ b/internal/domain/transfer_test.go
@@ -1,0 +1,39 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+)
+
+func TestTransfer_FromAndToTxIDs_NilByDefault(t *testing.T) {
+	tr := &domain.Transfer{}
+	assert.Nil(t, tr.FromTxID, "transfers created before migration 00020 leave linked tx IDs nil")
+	assert.Nil(t, tr.ToTxID)
+}
+
+func TestTransfer_LinkedTransactionIDs_PointToOwnedRows(t *testing.T) {
+	fromTx := int64(101)
+	toTx := int64(102)
+	tr := &domain.Transfer{
+		FromAccountID:    1,
+		ToAccountID:      2,
+		FromCurrencyCode: "USD",
+		ToCurrencyCode:   "EUR",
+		ExchangeRate:     0.92,
+		FromTxID:         &fromTx,
+		ToTxID:           &toTx,
+	}
+
+	assert.NotEqual(t, tr.FromAccountID, tr.ToAccountID, "transfer requires distinct accounts")
+	assert.Equal(t, "USD", tr.FromCurrencyCode)
+	assert.Equal(t, "EUR", tr.ToCurrencyCode)
+	require := tr.FromTxID
+	require2 := tr.ToTxID
+	assert.NotNil(t, require)
+	assert.NotNil(t, require2)
+	assert.Equal(t, int64(101), *require)
+	assert.Equal(t, int64(102), *require2)
+}

--- a/internal/repository/account_test.go
+++ b/internal/repository/account_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/repository"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+func newAccountRepoFixtures(t *testing.T) (*repository.AccountRepository, int64) {
+	t.Helper()
+	pool := testutil.OpenTestPool(t)
+	testutil.CleanupTables(t, pool)
+	t.Cleanup(func() { testutil.CleanupTables(t, pool) })
+
+	userID := testutil.SeedUser(t, pool, time.Now().UnixNano())
+	return repository.NewAccountRepository(pool), userID
+}
+
+func TestAccountRepository_CreateAndGetByID(t *testing.T) {
+	repo, userID := newAccountRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Account{
+		UserID:         userID,
+		Name:           "Main",
+		Icon:           "wallet",
+		Color:          "#6366f1",
+		Type:           domain.AccountTypeChecking,
+		CurrencyCode:   "USD",
+		IsDefault:      true,
+		IncludeInTotal: true,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+
+	fetched, err := repo.GetByID(ctx, created.ID, userID)
+	require.NoError(t, err)
+	assert.Equal(t, "Main", fetched.Name)
+	assert.Equal(t, "USD", fetched.CurrencyCode)
+	assert.True(t, fetched.IsDefault)
+	assert.Equal(t, domain.AccountTypeChecking, fetched.Type)
+}
+
+func TestAccountRepository_GetByID_OtherUser_ReturnsErrAccountNotFound(t *testing.T) {
+	repo, owner := newAccountRepoFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	stranger := testutil.SeedUser(t, pool, time.Now().UnixNano()+1)
+
+	ctx := context.Background()
+	created, err := repo.Create(ctx, &domain.Account{
+		UserID: owner, Name: "Main", Icon: "wallet", Color: "#000",
+		Type: domain.AccountTypeChecking, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	_, err = repo.GetByID(ctx, created.ID, stranger)
+	assert.ErrorIs(t, err, domain.ErrAccountNotFound)
+}
+
+func TestAccountRepository_ListByUser_OnlyOwnAccounts(t *testing.T) {
+	repo, user1 := newAccountRepoFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	user2 := testutil.SeedUser(t, pool, time.Now().UnixNano()+2)
+
+	ctx := context.Background()
+	for i, name := range []string{"Cash", "Card"} {
+		_, err := repo.Create(ctx, &domain.Account{
+			UserID: user1, Name: name, Icon: "wallet", Color: "#000",
+			Type: domain.AccountTypeChecking, CurrencyCode: "USD",
+			IsDefault: i == 0,
+		})
+		require.NoError(t, err)
+	}
+	_, err := repo.Create(ctx, &domain.Account{
+		UserID: user2, Name: "Other", Icon: "wallet", Color: "#000",
+		Type: domain.AccountTypeChecking, CurrencyCode: "EUR",
+	})
+	require.NoError(t, err)
+
+	list, err := repo.ListByUser(ctx, user1)
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+	for _, a := range list {
+		assert.Equal(t, user1, a.UserID)
+	}
+}
+
+func TestAccountRepository_SetDefault_MovesFlag(t *testing.T) {
+	repo, userID := newAccountRepoFixtures(t)
+	ctx := context.Background()
+
+	a1, err := repo.Create(ctx, &domain.Account{
+		UserID: userID, Name: "First", Icon: "wallet", Color: "#000",
+		Type: domain.AccountTypeChecking, CurrencyCode: "USD", IsDefault: true,
+	})
+	require.NoError(t, err)
+	a2, err := repo.Create(ctx, &domain.Account{
+		UserID: userID, Name: "Second", Icon: "wallet", Color: "#000",
+		Type: domain.AccountTypeChecking, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	switched, err := repo.SetDefault(ctx, a2.ID, userID)
+	require.NoError(t, err)
+	assert.True(t, switched.IsDefault)
+
+	first, err := repo.GetByID(ctx, a1.ID, userID)
+	require.NoError(t, err)
+	assert.False(t, first.IsDefault, "old default must be cleared")
+}
+
+func TestAccountRepository_Update_KeepsCurrencyImmutable(t *testing.T) {
+	repo, userID := newAccountRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Account{
+		UserID: userID, Name: "Main", Icon: "wallet", Color: "#111",
+		Type: domain.AccountTypeChecking, CurrencyCode: "USD", IncludeInTotal: true,
+	})
+	require.NoError(t, err)
+
+	updated, err := repo.Update(ctx, &domain.Account{
+		ID: created.ID, UserID: userID,
+		Name: "Renamed", Icon: "card", Color: "#222",
+		Type:           domain.AccountTypeCash,
+		CurrencyCode:   "EUR", // ignored — currency is immutable
+		IncludeInTotal: false,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Renamed", updated.Name)
+	assert.Equal(t, "card", updated.Icon)
+	assert.Equal(t, "USD", updated.CurrencyCode, "currency_code must stay USD")
+	assert.False(t, updated.IncludeInTotal)
+}

--- a/internal/repository/category_test.go
+++ b/internal/repository/category_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/repository"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+func newCategoryRepoFixtures(t *testing.T) (*repository.CategoryRepository, int64) {
+	t.Helper()
+	pool := testutil.OpenTestPool(t)
+	testutil.CleanupTables(t, pool)
+	t.Cleanup(func() { testutil.CleanupTables(t, pool) })
+
+	userID := testutil.SeedUser(t, pool, time.Now().UnixNano())
+	return repository.NewCategoryRepository(pool), userID
+}
+
+func TestCategoryRepository_CreateForUser_PersistsAttributes(t *testing.T) {
+	repo, userID := newCategoryRepoFixtures(t)
+	ctx := context.Background()
+
+	cat, err := repo.CreateForUser(ctx, userID, "Coffee", "coffee", "expense", "#a87654")
+	require.NoError(t, err)
+	require.NotZero(t, cat.ID)
+	assert.Equal(t, "Coffee", cat.Name)
+	assert.Equal(t, "coffee", cat.Icon)
+	assert.Equal(t, domain.CategoryType("expense"), cat.Type)
+	assert.Equal(t, "#a87654", cat.Color)
+}
+
+func TestCategoryRepository_ListForUser_ScopedToUser(t *testing.T) {
+	repo, user1 := newCategoryRepoFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	user2 := testutil.SeedUser(t, pool, time.Now().UnixNano()+1)
+
+	ctx := context.Background()
+	_, err := repo.CreateForUser(ctx, user1, "Food", "food", "expense", "#fff")
+	require.NoError(t, err)
+	_, err = repo.CreateForUser(ctx, user2, "Travel", "globe", "expense", "#000")
+	require.NoError(t, err)
+
+	cats, err := repo.ListForUser(ctx, user1)
+	require.NoError(t, err)
+	for _, c := range cats {
+		assert.NotEqual(t, "Travel", c.Name, "user1 must not see user2 categories")
+	}
+	hasFood := false
+	for _, c := range cats {
+		if c.Name == "Food" {
+			hasFood = true
+		}
+	}
+	assert.True(t, hasFood, "user1 must see their own Food category")
+}
+
+func TestCategoryRepository_GetByName_ReturnsErrCategoryNotFound(t *testing.T) {
+	repo, userID := newCategoryRepoFixtures(t)
+	ctx := context.Background()
+
+	_, err := repo.GetByName(ctx, userID, "NonExistent")
+	assert.ErrorIs(t, err, domain.ErrCategoryNotFound)
+}
+
+func TestCategoryRepository_Update_ChangesMutableFields(t *testing.T) {
+	repo, userID := newCategoryRepoFixtures(t)
+	ctx := context.Background()
+
+	cat, err := repo.CreateForUser(ctx, userID, "Food", "food", "expense", "#fff")
+	require.NoError(t, err)
+
+	updated, err := repo.Update(ctx, userID, cat.ID, "Groceries", "shopping-cart", "expense", "#abc")
+	require.NoError(t, err)
+	assert.Equal(t, "Groceries", updated.Name)
+	assert.Equal(t, "shopping-cart", updated.Icon)
+	assert.Equal(t, "#abc", updated.Color)
+}
+
+func TestCategoryRepository_SoftDelete_HidesFromList(t *testing.T) {
+	repo, userID := newCategoryRepoFixtures(t)
+	ctx := context.Background()
+
+	cat, err := repo.CreateForUser(ctx, userID, "Hobbies", "music-note", "expense", "#fff")
+	require.NoError(t, err)
+
+	require.NoError(t, repo.SoftDelete(ctx, cat.ID, userID))
+
+	cats, err := repo.ListForUser(ctx, userID)
+	require.NoError(t, err)
+	for _, c := range cats {
+		assert.NotEqual(t, cat.ID, c.ID, "soft-deleted category must not appear in ListForUser")
+	}
+}

--- a/internal/repository/transaction_test.go
+++ b/internal/repository/transaction_test.go
@@ -1,0 +1,162 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/repository"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+func newTransactionFixtures(t *testing.T) (*repository.TransactionRepository, int64, int64, int64) {
+	t.Helper()
+	pool := testutil.OpenTestPool(t)
+	testutil.CleanupTables(t, pool)
+	t.Cleanup(func() { testutil.CleanupTables(t, pool) })
+
+	userID := testutil.SeedUser(t, pool, time.Now().UnixNano())
+	accountID := testutil.SeedAccount(t, pool, userID, "USD")
+	categoryID := testutil.SeedCategory(t, pool, userID, "Food", "expense")
+
+	return repository.NewTransactionRepository(pool), userID, accountID, categoryID
+}
+
+func TestTransactionRepository_Create_PersistsAllFields(t *testing.T) {
+	repo, userID, accountID, categoryID := newTransactionFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Transaction{
+		UserID:       userID,
+		Type:         domain.TransactionTypeExpense,
+		AmountCents:  1500,
+		CategoryID:   categoryID,
+		AccountID:    accountID,
+		Note:         "Lunch",
+		CurrencyCode: "USD",
+		SnapshotDate: time.Now().UTC().Truncate(24 * time.Hour),
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+	assert.Equal(t, userID, created.UserID)
+	assert.Equal(t, domain.TransactionTypeExpense, created.Type)
+	assert.Equal(t, int64(1500), created.AmountCents)
+	assert.Equal(t, categoryID, created.CategoryID)
+	assert.Equal(t, accountID, created.AccountID)
+	assert.Equal(t, "USD", created.CurrencyCode)
+	assert.Equal(t, "Lunch", created.Note)
+	assert.False(t, created.IsAdjustment)
+}
+
+func TestTransactionRepository_List_ScopedToUser(t *testing.T) {
+	repo, user1, acct1, cat1 := newTransactionFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	user2 := testutil.SeedUser(t, pool, time.Now().UnixNano()+1)
+	acct2 := testutil.SeedAccount(t, pool, user2, "USD")
+	cat2 := testutil.SeedCategory(t, pool, user2, "Food", "expense")
+
+	ctx := context.Background()
+	_, err := repo.Create(ctx, &domain.Transaction{
+		UserID: user1, Type: domain.TransactionTypeExpense, AmountCents: 100,
+		CategoryID: cat1, AccountID: acct1, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+	_, err = repo.Create(ctx, &domain.Transaction{
+		UserID: user2, Type: domain.TransactionTypeExpense, AmountCents: 200,
+		CategoryID: cat2, AccountID: acct2, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	list1, err := repo.List(ctx, user1, 10, 0)
+	require.NoError(t, err)
+	assert.Len(t, list1, 1)
+	assert.Equal(t, int64(100), list1[0].AmountCents)
+
+	list2, err := repo.List(ctx, user2, 10, 0)
+	require.NoError(t, err)
+	assert.Len(t, list2, 1)
+	assert.Equal(t, int64(200), list2[0].AmountCents)
+}
+
+func TestTransactionRepository_Delete_ScopedToUser(t *testing.T) {
+	repo, owner, acct, cat := newTransactionFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	other := testutil.SeedUser(t, pool, time.Now().UnixNano()+2)
+
+	ctx := context.Background()
+	created, err := repo.Create(ctx, &domain.Transaction{
+		UserID: owner, Type: domain.TransactionTypeExpense, AmountCents: 100,
+		CategoryID: cat, AccountID: acct, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	// Delete attempted by a different user — must be a no-op.
+	require.NoError(t, repo.Delete(ctx, created.ID, other))
+
+	count, err := repo.Count(ctx, owner)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count, "transaction must still belong to the owner")
+
+	// Owner can delete their own row.
+	require.NoError(t, repo.Delete(ctx, created.ID, owner))
+	count, err = repo.Count(ctx, owner)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+}
+
+func TestTransactionRepository_GetBalance_SumsByType(t *testing.T) {
+	repo, userID, accountID, categoryID := newTransactionFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	incomeCat := testutil.SeedCategory(t, pool, userID, "Salary", "income")
+
+	ctx := context.Background()
+	_, err := repo.Create(ctx, &domain.Transaction{
+		UserID: userID, Type: domain.TransactionTypeExpense, AmountCents: 300,
+		CategoryID: categoryID, AccountID: accountID, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+	_, err = repo.Create(ctx, &domain.Transaction{
+		UserID: userID, Type: domain.TransactionTypeExpense, AmountCents: 200,
+		CategoryID: categoryID, AccountID: accountID, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+	_, err = repo.Create(ctx, &domain.Transaction{
+		UserID: userID, Type: domain.TransactionTypeIncome, AmountCents: 1000,
+		CategoryID: incomeCat, AccountID: accountID, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	income, expense, err := repo.GetBalance(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1000), income)
+	assert.Equal(t, int64(500), expense)
+}
+
+func TestTransactionRepository_Update_ChangesMutableFields(t *testing.T) {
+	repo, userID, accountID, categoryID := newTransactionFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Transaction{
+		UserID: userID, Type: domain.TransactionTypeExpense, AmountCents: 100,
+		CategoryID: categoryID, AccountID: accountID, Note: "original", CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	updated, err := repo.Update(ctx, &domain.Transaction{
+		ID:          created.ID,
+		UserID:      userID,
+		AmountCents: 250,
+		CategoryID:  categoryID,
+		Note:        "amended",
+		CreatedAt:   created.CreatedAt,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(250), updated.AmountCents)
+	assert.Equal(t, "amended", updated.Note)
+}

--- a/internal/service/admin_test.go
+++ b/internal/service/admin_test.go
@@ -1,0 +1,161 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/service"
+	"github.com/horexdev/money-tracker/internal/testutil"
+	"github.com/horexdev/money-tracker/internal/testutil/mocks"
+)
+
+func newAdminService(repo *mocks.MockAdminStorer) *service.AdminService {
+	return service.NewAdminService(repo, testutil.TestLogger())
+}
+
+func TestAdminService_ListUsers_ClampsPageAndPageSize(t *testing.T) {
+	t.Run("page<1 becomes 1, pageSize<1 becomes 20", func(t *testing.T) {
+		repo := &mocks.MockAdminStorer{}
+		svc := newAdminService(repo)
+		repo.On("CountUsers", mock.Anything).Return(int64(50), nil)
+		repo.On("ListUsers", mock.Anything, 20, 0).Return([]*domain.User{{ID: 1}}, nil)
+
+		_, total, err := svc.ListUsers(context.Background(), 0, 0)
+		require.NoError(t, err)
+		assert.Equal(t, int64(50), total)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("pageSize>100 becomes 20", func(t *testing.T) {
+		repo := &mocks.MockAdminStorer{}
+		svc := newAdminService(repo)
+		repo.On("CountUsers", mock.Anything).Return(int64(0), nil)
+		repo.On("ListUsers", mock.Anything, 20, 0).Return([]*domain.User{}, nil)
+
+		_, _, err := svc.ListUsers(context.Background(), 1, 500)
+		require.NoError(t, err)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("offset = (page-1)*pageSize", func(t *testing.T) {
+		repo := &mocks.MockAdminStorer{}
+		svc := newAdminService(repo)
+		repo.On("CountUsers", mock.Anything).Return(int64(0), nil)
+		repo.On("ListUsers", mock.Anything, 25, 50).Return([]*domain.User{}, nil)
+
+		_, _, err := svc.ListUsers(context.Background(), 3, 25)
+		require.NoError(t, err)
+		repo.AssertExpectations(t)
+	})
+}
+
+func TestAdminService_ListUsers_ReturnsCountError(t *testing.T) {
+	repo := &mocks.MockAdminStorer{}
+	svc := newAdminService(repo)
+	repo.On("CountUsers", mock.Anything).Return(int64(0), errors.New("db down"))
+
+	users, total, err := svc.ListUsers(context.Background(), 1, 20)
+	assert.Error(t, err)
+	assert.Nil(t, users)
+	assert.Zero(t, total)
+}
+
+func TestAdminService_GetStats_AggregatesAllMetrics(t *testing.T) {
+	repo := &mocks.MockAdminStorer{}
+	svc := newAdminService(repo)
+
+	repo.On("CountUsers", mock.Anything).Return(int64(1000), nil)
+	// Three CountNewUsers calls for today/week/month
+	repo.On("CountNewUsers", mock.Anything, mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return(int64(5), nil)
+	// Three more for cohort retention day-1, day-7, day-30
+	repo.On("CountRetainedUsers", mock.Anything,
+		mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time"),
+		mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return(int64(3), nil)
+
+	stats, err := svc.GetStats(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stats)
+	assert.Equal(t, int64(1000), stats.TotalUsers)
+	assert.Equal(t, int64(5), stats.NewToday)
+	assert.Equal(t, int64(5), stats.NewThisWeek)
+	assert.Equal(t, int64(5), stats.NewThisMonth)
+	// Retention is 3/5 = 60% for each window since CountNewUsers returns 5 too.
+	assert.InDelta(t, 60.0, stats.RetentionDay1, 0.01)
+	assert.InDelta(t, 60.0, stats.RetentionDay7, 0.01)
+	assert.InDelta(t, 60.0, stats.RetentionDay30, 0.01)
+}
+
+func TestAdminService_GetStats_RetentionZeroWhenCohortEmpty(t *testing.T) {
+	repo := &mocks.MockAdminStorer{}
+	svc := newAdminService(repo)
+
+	repo.On("CountUsers", mock.Anything).Return(int64(10), nil)
+	repo.On("CountNewUsers", mock.Anything, mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return(int64(0), nil)
+	// CountRetainedUsers should not be called when cohortSize == 0, but stub it
+	// just in case to keep the mock unstrict.
+	repo.On("CountRetainedUsers", mock.Anything,
+		mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time"),
+		mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return(int64(0), nil).Maybe()
+
+	stats, err := svc.GetStats(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), stats.RetentionDay1)
+	assert.Equal(t, float64(0), stats.RetentionDay7)
+	assert.Equal(t, float64(0), stats.RetentionDay30)
+}
+
+func TestAdminService_ListAllUserIDs_PassesThrough(t *testing.T) {
+	repo := &mocks.MockAdminStorer{}
+	svc := newAdminService(repo)
+	repo.On("ListAllUserIDs", mock.Anything).Return([]int64{1, 2, 3}, nil)
+
+	ids, err := svc.ListAllUserIDs(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []int64{1, 2, 3}, ids)
+}
+
+// TestAdminService_GetStats_TimeBoundaries verifies the service computes
+// today/week/month boundaries correctly: today should start at 00:00 UTC,
+// week at the most recent Sunday, month at the 1st.
+func TestAdminService_GetStats_TimeBoundaries(t *testing.T) {
+	repo := &mocks.MockAdminStorer{}
+	svc := newAdminService(repo)
+
+	repo.On("CountUsers", mock.Anything).Return(int64(0), nil)
+
+	var capturedFrom []time.Time
+	repo.On("CountNewUsers", mock.Anything, mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return(int64(0), nil).
+		Run(func(args mock.Arguments) {
+			capturedFrom = append(capturedFrom, args.Get(1).(time.Time))
+		})
+	repo.On("CountRetainedUsers", mock.Anything,
+		mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time"),
+		mock.AnythingOfType("time.Time"), mock.AnythingOfType("time.Time")).
+		Return(int64(0), nil).Maybe()
+
+	_, err := svc.GetStats(context.Background())
+	require.NoError(t, err)
+	// CountNewUsers is called 6 times: 3 windows (today/week/month) + 3 cohort sizes
+	// (day-1, day-7, day-30). We only assert on the first three.
+	require.GreaterOrEqual(t, len(capturedFrom), 3, "expected at least 3 CountNewUsers calls")
+
+	// today at 00:00 UTC
+	assert.Equal(t, 0, capturedFrom[0].Hour())
+	assert.Equal(t, 0, capturedFrom[0].Minute())
+	// week start is at or before today
+	assert.True(t, !capturedFrom[1].After(capturedFrom[0]))
+	// month start is the 1st
+	assert.Equal(t, 1, capturedFrom[2].Day())
+}

--- a/internal/service/export_test.go
+++ b/internal/service/export_test.go
@@ -1,0 +1,125 @@
+package service_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/service"
+	"github.com/horexdev/money-tracker/internal/testutil"
+	"github.com/horexdev/money-tracker/internal/testutil/mocks"
+)
+
+func newExportService(repo *mocks.MockTransactionStorer) *service.ExportService {
+	return service.NewExportService(repo, testutil.TestLogger())
+}
+
+func readCSV(t *testing.T, data []byte) [][]string {
+	t.Helper()
+	rows, err := csv.NewReader(bytes.NewReader(data)).ReadAll()
+	require.NoError(t, err)
+	return rows
+}
+
+func TestExportService_ExportCSV_HeaderOnly_WhenNoData(t *testing.T) {
+	repo := &mocks.MockTransactionStorer{}
+	svc := newExportService(repo)
+	repo.On("List", mock.Anything, int64(1), 500, 0).Return([]*domain.Transaction{}, nil)
+
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 4, 30, 23, 59, 59, 0, time.UTC)
+
+	out, err := svc.ExportCSV(context.Background(), 1, from, to)
+	require.NoError(t, err)
+
+	rows := readCSV(t, out)
+	require.Len(t, rows, 1)
+	assert.Equal(t, []string{"Date", "Type", "Amount", "Currency", "Category", "Note"}, rows[0])
+}
+
+func TestExportService_ExportCSV_WritesAllRowsInRange(t *testing.T) {
+	repo := &mocks.MockTransactionStorer{}
+	svc := newExportService(repo)
+
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	txs := []*domain.Transaction{
+		{
+			CreatedAt: time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC),
+			Type:      domain.TransactionTypeExpense,
+			AmountCents: 1500, CurrencyCode: "USD", CategoryName: "Food", Note: "lunch",
+		},
+		{
+			CreatedAt: time.Date(2026, 4, 15, 8, 0, 0, 0, time.UTC),
+			Type:      domain.TransactionTypeIncome,
+			AmountCents: 100000, CurrencyCode: "USD", CategoryName: "Salary",
+		},
+	}
+	repo.On("List", mock.Anything, int64(1), 500, 0).Return(txs, nil)
+
+	out, err := svc.ExportCSV(context.Background(), 1, from, to)
+	require.NoError(t, err)
+
+	rows := readCSV(t, out)
+	require.Len(t, rows, 3, "header + 2 transactions")
+	assert.Equal(t, "expense", rows[1][1])
+	assert.Equal(t, "15.00", rows[1][2])
+	assert.Equal(t, "USD", rows[1][3])
+	assert.Equal(t, "Food", rows[1][4])
+	assert.Equal(t, "lunch", rows[1][5])
+	assert.Equal(t, "income", rows[2][1])
+	assert.Equal(t, "1000.00", rows[2][2])
+}
+
+func TestExportService_ExportCSV_StopsAtTransactionsBeforeFrom(t *testing.T) {
+	repo := &mocks.MockTransactionStorer{}
+	svc := newExportService(repo)
+
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	txs := []*domain.Transaction{
+		{
+			CreatedAt: time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC),
+			Type:      domain.TransactionTypeExpense,
+			AmountCents: 100, CurrencyCode: "USD", CategoryName: "A",
+		},
+		{
+			CreatedAt: time.Date(2026, 4, 5, 0, 0, 0, 0, time.UTC),
+			Type:      domain.TransactionTypeExpense,
+			AmountCents: 200, CurrencyCode: "USD", CategoryName: "B",
+		},
+		{
+			CreatedAt: time.Date(2026, 3, 30, 0, 0, 0, 0, time.UTC),
+			Type:      domain.TransactionTypeExpense,
+			AmountCents: 300, CurrencyCode: "USD", CategoryName: "C",
+		},
+	}
+	repo.On("List", mock.Anything, int64(1), 500, 0).Return(txs, nil)
+
+	out, err := svc.ExportCSV(context.Background(), 1, from, to)
+	require.NoError(t, err)
+
+	rows := readCSV(t, out)
+	require.Len(t, rows, 3, "header + 2 in-range rows; pre-range tx must skip")
+}
+
+func TestExportService_ExportCSV_RepoErrorPropagates(t *testing.T) {
+	repo := &mocks.MockTransactionStorer{}
+	svc := newExportService(repo)
+	repo.On("List", mock.Anything, int64(1), 500, 0).Return(nil, errors.New("db down"))
+
+	out, err := svc.ExportCSV(context.Background(), 1, time.Now(), time.Now())
+	assert.Nil(t, out)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list transactions for export")
+}

--- a/internal/service/stats_test.go
+++ b/internal/service/stats_test.go
@@ -1,0 +1,114 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/service"
+	"github.com/horexdev/money-tracker/internal/testutil"
+	"github.com/horexdev/money-tracker/internal/testutil/mocks"
+)
+
+func newStatsService(repo *mocks.MockTransactionStorer) *service.StatsService {
+	return service.NewStatsService(repo, testutil.TestLogger())
+}
+
+func TestStatsService_ByCategory_PassesArgsAndResult(t *testing.T) {
+	repo := &mocks.MockTransactionStorer{}
+	svc := newStatsService(repo)
+
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 1, 31, 23, 59, 59, 0, time.UTC)
+	expected := []domain.CategoryStat{
+		{CategoryName: "Food", Type: domain.TransactionTypeExpense, TotalCents: 1500, TxCount: 3, CurrencyCode: "USD"},
+	}
+	repo.On("StatsByCategory", mock.Anything, int64(42), from, to).Return(expected, nil)
+
+	got, err := svc.ByCategory(context.Background(), 42, from, to)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
+	repo.AssertExpectations(t)
+}
+
+func TestStatsService_ByCategory_WrapsRepoError(t *testing.T) {
+	repo := &mocks.MockTransactionStorer{}
+	svc := newStatsService(repo)
+	repo.On("StatsByCategory", mock.Anything, int64(1), mock.Anything, mock.Anything).
+		Return(nil, errors.New("db down"))
+
+	stats, err := svc.ByCategory(context.Background(), 1, time.Now(), time.Now())
+	assert.Nil(t, stats)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stats by category for user 1")
+}
+
+func TestStatsService_ByCategoryAndAccount_PassesAccountID(t *testing.T) {
+	repo := &mocks.MockTransactionStorer{}
+	svc := newStatsService(repo)
+
+	from := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	to := from.AddDate(0, 1, 0)
+	repo.On("StatsByCategoryAndAccount", mock.Anything, int64(7), int64(99), from, to).
+		Return([]domain.CategoryStat{}, nil)
+
+	_, err := svc.ByCategoryAndAccount(context.Background(), 7, 99, from, to)
+	require.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestStatsService_PeriodRange(t *testing.T) {
+	t.Run("today spans midnight to midnight", func(t *testing.T) {
+		from, to, err := service.PeriodRange("today")
+		require.NoError(t, err)
+		assert.Equal(t, 24*time.Hour, to.Sub(from))
+		assert.Equal(t, 0, from.Hour())
+	})
+
+	t.Run("week spans seven days", func(t *testing.T) {
+		from, to, err := service.PeriodRange("week")
+		require.NoError(t, err)
+		assert.Equal(t, 7*24*time.Hour, to.Sub(from))
+	})
+
+	t.Run("month starts on day 1", func(t *testing.T) {
+		from, _, err := service.PeriodRange("month")
+		require.NoError(t, err)
+		assert.Equal(t, 1, from.Day())
+		assert.Equal(t, 0, from.Hour())
+	})
+
+	t.Run("lastmonth ends at start of current month", func(t *testing.T) {
+		_, to, err := service.PeriodRange("lastmonth")
+		require.NoError(t, err)
+		assert.Equal(t, 1, to.Day())
+	})
+
+	t.Run("lastweek precedes week", func(t *testing.T) {
+		from, _, err := service.PeriodRange("lastweek")
+		require.NoError(t, err)
+		now := time.Now()
+		assert.True(t, from.Before(now))
+	})
+
+	t.Run("3months covers current and two preceding", func(t *testing.T) {
+		from, to, err := service.PeriodRange("3months")
+		require.NoError(t, err)
+		assert.True(t, to.After(from))
+		// 3 months ≈ 89-92 days; assert the span is within a sane window.
+		span := to.Sub(from).Hours() / 24
+		assert.GreaterOrEqual(t, span, 58.0)
+		assert.LessOrEqual(t, span, 95.0)
+	})
+
+	t.Run("invalid period returns ErrInvalidPeriod", func(t *testing.T) {
+		_, _, err := service.PeriodRange("eternity")
+		assert.ErrorIs(t, err, domain.ErrInvalidPeriod)
+	})
+}

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -1,0 +1,59 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+// OpenTestPool opens a pgx pool to the integration-test database.
+// It reads TEST_DATABASE_URL or falls back to DATABASE_URL — the same env
+// variable the CI integration-tests job exports. If neither is set, the
+// test is skipped so local `make test-unit` runs stay green.
+func OpenTestPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		dsn = os.Getenv("DATABASE_URL")
+	}
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL or DATABASE_URL not set; skipping integration test")
+	}
+
+	pool, err := pgxpool.New(context.Background(), dsn)
+	require.NoError(t, err, "open pgx pool")
+	t.Cleanup(pool.Close)
+
+	require.NoError(t, pool.Ping(context.Background()), "ping db")
+	return pool
+}
+
+// CleanupTables removes all user-scoped data, leaving system rows
+// (e.g. seeded categories with user_id IS NULL) intact. Call it via
+// t.Cleanup at the start of each test, and once more at the top to
+// recover from a previously aborted run.
+func CleanupTables(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	stmts := []string{
+		`DELETE FROM goal_transactions`,
+		`DELETE FROM savings_goals`,
+		`DELETE FROM budgets`,
+		`DELETE FROM recurring_transactions`,
+		`DELETE FROM transfers`,
+		`DELETE FROM transactions`,
+		`DELETE FROM accounts`,
+		`DELETE FROM exchange_rate_snapshots`,
+		`DELETE FROM categories WHERE user_id IS NOT NULL`,
+		`DELETE FROM users`,
+	}
+	for _, sql := range stmts {
+		_, err := pool.Exec(ctx, sql)
+		require.NoErrorf(t, err, "cleanup: %s", sql)
+	}
+}

--- a/internal/testutil/db_seed.go
+++ b/internal/testutil/db_seed.go
@@ -1,0 +1,51 @@
+//go:build integration
+
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+// SeedUser inserts a minimal users row with the given Telegram ID. The other
+// columns rely on the schema's defaults. Returns the user ID for chaining.
+func SeedUser(t *testing.T, pool *pgxpool.Pool, id int64) int64 {
+	t.Helper()
+	_, err := pool.Exec(context.Background(), `
+		INSERT INTO users (id, username, first_name)
+		VALUES ($1, $2, $3)
+	`, id, "test_user", "Test")
+	require.NoError(t, err, "seed user")
+	return id
+}
+
+// SeedAccount inserts an account for the given user and returns its ID.
+// The account is non-default and included in the user's total.
+func SeedAccount(t *testing.T, pool *pgxpool.Pool, userID int64, currency string) int64 {
+	t.Helper()
+	var id int64
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO accounts (user_id, name, currency_code, is_default, include_in_total)
+		VALUES ($1, 'Test Account', $2, false, true)
+		RETURNING id
+	`, userID, currency).Scan(&id)
+	require.NoError(t, err, "seed account")
+	return id
+}
+
+// SeedCategory inserts a personal category for the user and returns its ID.
+// catType must be one of: expense, income, both, transfer, adjustment, savings.
+func SeedCategory(t *testing.T, pool *pgxpool.Pool, userID int64, name, catType string) int64 {
+	t.Helper()
+	var id int64
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO categories (user_id, name, icon, type, color)
+		VALUES ($1, $2, 'package', $3, '#6366f1')
+		RETURNING id
+	`, userID, name, catType).Scan(&id)
+	require.NoError(t, err, "seed category")
+	return id
+}

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
 *.local
 
 # Editor directories and files

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.4.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.4.0",
+      "version": "1.6.0",
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@tanstack/react-query": "^5.95.2",
@@ -23,19 +23,68 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@tailwindcss/vite": "^4.2.2",
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.1.0",
+        "@testing-library/user-event": "^14.5.2",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
+        "@vitest/coverage-v8": "^2.1.9",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^26.1.0",
         "tailwindcss": "^4.2.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
-        "vite": "^8.0.1"
+        "vite": "^8.0.1",
+        "vitest": "^2.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -286,6 +335,128 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
@@ -318,6 +489,474 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -529,6 +1168,34 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -617,6 +1284,17 @@
       "peerDependencies": {
         "react": ">= 16.8",
         "react-dom": ">= 16.8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -880,6 +1558,356 @@
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
@@ -1179,6 +2207,95 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tma.js/bridge": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@tma.js/bridge/-/bridge-2.2.3.tgz",
@@ -1275,6 +2392,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1641,6 +2765,125 @@
         }
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1664,6 +2907,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -1679,6 +2932,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1703,6 +2966,26 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -1778,6 +3061,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1809,6 +3102,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1824,6 +3134,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -1888,12 +3208,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/date-fns": {
       "version": "4.1.0",
@@ -1923,12 +3278,39 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1940,12 +3322,33 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.325",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
       "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -1961,11 +3364,75 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-kid": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/error-kid/-/error-kid-1.1.0.tgz",
       "integrity": "sha512-PwVk1XJt8bOAkptsG/ezLwh64m3TrWjCW8X95wnDjPjHRkkn3/I13m76zuFrGVr/zLsCZao+08OsOcJbUNEPZg==",
       "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2164,6 +3631,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2172,6 +3649,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2264,6 +3751,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fp-ts": {
       "version": "2.16.11",
       "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-2.16.11.tgz",
@@ -2322,6 +3826,28 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2333,6 +3859,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -2382,6 +3934,26 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-parse-stringify": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
@@ -2389,6 +3961,34 @@
       "license": "MIT",
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/i18next": {
@@ -2431,6 +4031,19 @@
         "@babel/runtime": "^7.23.2"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2468,6 +4081,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2476,6 +4099,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2491,12 +4124,89 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -2526,6 +4236,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -2883,6 +4633,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2893,6 +4650,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2901,6 +4668,57 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -2914,6 +4732,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
@@ -2977,6 +4805,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3027,6 +4862,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3038,6 +4880,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -3058,6 +4913,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3119,6 +5015,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3177,6 +5101,13 @@
         }
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-router": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
@@ -3213,6 +5144,20 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -3266,6 +5211,78 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3311,6 +5328,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3319,6 +5356,130 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3347,6 +5508,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
@@ -3368,6 +5536,74 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3383,6 +5619,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3604,6 +5916,1102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -3611,6 +7019,67 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -3629,6 +7098,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3638,6 +7124,130 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -25,17 +25,24 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.2.2",
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
+    "@vitest/coverage-v8": "^2.1.9",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4.2.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
-    "vite": "^8.0.1"
+    "vite": "^8.0.1",
+    "vitest": "^2.1.9"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",

--- a/web/src/features/add-transaction/index.test.tsx
+++ b/web/src/features/add-transaction/index.test.tsx
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+vi.mock('../../shared/api/categories', () => ({
+  categoriesApi: {
+    list: vi.fn().mockResolvedValue({
+      categories: [
+        { id: 1, name: 'Food', icon: 'Food', color: '#ff0000', type: 'expense' },
+        { id: 2, name: 'Salary', icon: 'Salary', color: '#00ff00', type: 'income' },
+      ],
+    }),
+  },
+}))
+
+vi.mock('../../shared/api/transactions', () => ({
+  transactionsApi: {
+    list: vi.fn(),
+    create: vi.fn().mockResolvedValue({ id: 100 }),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('../../shared/api/transfers', () => ({
+  transfersApi: {
+    list: vi.fn(),
+    create: vi.fn().mockResolvedValue({ id: 200 }),
+    delete: vi.fn(),
+  },
+  exchangeApi: {
+    getRate: vi.fn().mockResolvedValue({ rate: 1 }),
+  },
+}))
+
+vi.mock('../../shared/api/balance', () => ({
+  balanceApi: {
+    get: vi.fn().mockResolvedValue({
+      total_cents: 100000,
+      by_currency: [{ currency_code: 'USD', total_cents: 100000 }],
+    }),
+  },
+}))
+
+vi.mock('../../shared/api/accounts', () => ({
+  accountsApi: {
+    list: vi.fn().mockResolvedValue([
+      { id: 1, name: 'Main', currency_code: 'USD', is_default: true, balance_cents: 100000, icon: 'wallet', color: '#000', type: 'cash' },
+      { id: 2, name: 'Savings', currency_code: 'USD', is_default: false, balance_cents: 50000, icon: 'piggy', color: '#000', type: 'savings' },
+    ]),
+  },
+}))
+
+vi.mock('../../shared/hooks/useHaptic', () => ({
+  useHaptic: () => ({ impact: vi.fn(), notification: vi.fn(), selection: vi.fn() }),
+}))
+
+vi.mock('../../shared/hooks/useMainButton', () => ({
+  useTgMainButton: vi.fn(),
+}))
+
+import { AddTransactionPage } from './index'
+import { transactionsApi } from '../../shared/api/transactions'
+import { renderWithProviders } from '../../test/render'
+
+describe('AddTransactionPage smoke', () => {
+  beforeEach(() => {
+    vi.mocked(transactionsApi.create).mockClear()
+  })
+
+  it('renders the amount input and the three mode toggles', async () => {
+    renderWithProviders(<AddTransactionPage />)
+
+    expect(await screen.findByPlaceholderText('0.00')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /expense/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /income/i })).toBeInTheDocument()
+  })
+
+  it('calls transactionsApi.create when amount + category are picked and Save is clicked', async () => {
+    const user = userEvent.setup()
+    renderWithProviders(<AddTransactionPage />)
+
+    const input = await screen.findByPlaceholderText('0.00')
+    await user.type(input, '15')
+
+    const foodCategory = await screen.findByText('Food')
+    await user.click(foodCategory)
+
+    const saveButton = (await screen.findAllByRole('button')).find(
+      (b) => b.textContent?.trim().toLowerCase() === 'save',
+    )
+    expect(saveButton).toBeDefined()
+    await user.click(saveButton!)
+
+    await waitFor(() => {
+      expect(transactionsApi.create).toHaveBeenCalledTimes(1)
+    })
+
+    const firstCallPayload = vi.mocked(transactionsApi.create).mock.calls[0][0]
+    expect(firstCallPayload).toEqual(
+      expect.objectContaining({
+        category_id: 1,
+        type: 'expense',
+        amount_cents: 1500,
+        account_id: 1,
+      }),
+    )
+  })
+})

--- a/web/src/shared/api/client.test.ts
+++ b/web/src/shared/api/client.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { api } from './client'
+
+type FetchMock = ReturnType<typeof vi.fn>
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  })
+}
+
+function lastInit(fetchMock: FetchMock): RequestInit & { headers: Record<string, string> } {
+  const [, init] = fetchMock.mock.calls.at(-1) ?? []
+  return init as RequestInit & { headers: Record<string, string> }
+}
+
+describe('api client', () => {
+  let fetchMock: FetchMock
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('GET returns parsed JSON on 200', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ value: 42 }))
+    const result = await api.get<{ value: number }>('/v1/balance')
+    expect(result).toEqual({ value: 42 })
+  })
+
+  it('returns undefined on 204 No Content', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }))
+    const result = await api.delete<void>('/v1/things/1')
+    expect(result).toBeUndefined()
+  })
+
+  it('throws with response body on non-OK status', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('not found', { status: 404 }))
+    await expect(api.get('/v1/missing')).rejects.toThrow('not found')
+  })
+
+  it('falls back to "HTTP <status>" when body is empty', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 500 }))
+    await expect(api.get('/v1/boom')).rejects.toThrow('HTTP 500')
+  })
+
+  it('attaches the X-Telegram-Init-Data header', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}))
+    await api.get('/v1/anything')
+    expect(lastInit(fetchMock).headers['X-Telegram-Init-Data']).toBe('mock_init_data')
+  })
+
+  it('sends application/json by default', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}))
+    await api.get('/v1/anything')
+    expect(lastInit(fetchMock).headers['Content-Type']).toBe('application/json')
+  })
+
+  it('prefixes paths with /api', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}))
+    await api.get('/v1/balance')
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/v1/balance')
+  })
+
+  it('POST serialises body and sets POST method', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ id: 1 }))
+    await api.post('/v1/transactions', { amount_cents: 100 })
+    const init = lastInit(fetchMock)
+    expect(init.method).toBe('POST')
+    expect(init.body).toBe(JSON.stringify({ amount_cents: 100 }))
+  })
+
+  it.each(['put', 'patch'] as const)('%s serialises body with the right method', async (verb) => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}))
+    await api[verb]('/v1/things/1', { foo: 'bar' })
+    const init = lastInit(fetchMock)
+    expect(init.method).toBe(verb.toUpperCase())
+    expect(init.body).toBe(JSON.stringify({ foo: 'bar' }))
+  })
+
+  it('DELETE uses DELETE method without a body', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({}))
+    await api.delete('/v1/things/1')
+    const init = lastInit(fetchMock)
+    expect(init.method).toBe('DELETE')
+    expect(init.body).toBeUndefined()
+  })
+
+  it('aborts the request after 15 seconds', async () => {
+    vi.useFakeTimers()
+    fetchMock.mockImplementation((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('aborted', 'AbortError'))
+        })
+      }),
+    )
+
+    const promise = api.get('/v1/slow')
+    promise.catch(() => undefined)
+    await vi.advanceTimersByTimeAsync(15_001)
+    await expect(promise).rejects.toThrow(/abort/i)
+  })
+})

--- a/web/src/shared/api/transactions.test.ts
+++ b/web/src/shared/api/transactions.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import { api } from './client'
+import { transactionsApi, type CreateTransactionPayload, type UpdateTransactionPayload } from './transactions'
+
+const apiMock = api as unknown as Record<'get' | 'post' | 'put' | 'patch' | 'delete', ReturnType<typeof vi.fn>>
+
+beforeEach(() => {
+  apiMock.get.mockReset().mockResolvedValue({ items: [], total: 0 })
+  apiMock.post.mockReset().mockResolvedValue({ id: 1 })
+  apiMock.put.mockReset().mockResolvedValue({ id: 1 })
+  apiMock.delete.mockReset().mockResolvedValue(undefined)
+})
+
+describe('transactionsApi.list', () => {
+  it('uses defaults page=1, page_size=20 when no args given', async () => {
+    await transactionsApi.list()
+    expect(apiMock.get).toHaveBeenCalledTimes(1)
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/transactions?page=1&page_size=20')
+  })
+
+  it('passes through custom page and pageSize', async () => {
+    await transactionsApi.list(3, 50)
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/transactions?page=3&page_size=50')
+  })
+
+  it('appends optional accountId, from, to filters when provided', async () => {
+    await transactionsApi.list(1, 20, { accountId: 7, from: '2026-04-01', to: '2026-04-30' })
+    const url = apiMock.get.mock.calls[0][0]
+    expect(url).toContain('account_id=7')
+    expect(url).toContain('from=2026-04-01')
+    expect(url).toContain('to=2026-04-30')
+  })
+
+  it('omits filters that are null or undefined', async () => {
+    await transactionsApi.list(1, 20, { accountId: null, from: null, to: null })
+    const url = apiMock.get.mock.calls[0][0]
+    expect(url).not.toContain('account_id')
+    expect(url).not.toContain('from=')
+    expect(url).not.toContain('to=')
+  })
+})
+
+describe('transactionsApi.create', () => {
+  it('POSTs the payload to /v1/transactions', async () => {
+    const payload: CreateTransactionPayload = {
+      category_id: 5,
+      type: 'expense',
+      amount_cents: 1500,
+      account_id: 1,
+    }
+    await transactionsApi.create(payload)
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/transactions', payload)
+  })
+})
+
+describe('transactionsApi.update', () => {
+  it('PUTs to /v1/transactions/:id with payload', async () => {
+    const payload: UpdateTransactionPayload = {
+      amount_cents: 2500,
+      category_id: 5,
+      created_at: '2026-04-28T10:00:00Z',
+    }
+    await transactionsApi.update(42, payload)
+    expect(apiMock.put).toHaveBeenCalledWith('/v1/transactions/42', payload)
+  })
+})
+
+describe('transactionsApi.delete', () => {
+  it('DELETEs /v1/transactions/:id', async () => {
+    await transactionsApi.delete(42)
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/transactions/42')
+  })
+})

--- a/web/src/shared/hooks/useCategoryName.test.tsx
+++ b/web/src/shared/hooks/useCategoryName.test.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from 'react'
+import { describe, expect, it } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { I18nextProvider, initReactI18next } from 'react-i18next'
+import i18n from 'i18next'
+
+import { useCategoryName } from './useCategoryName'
+
+function buildI18n(lang: 'en' | 'ru' = 'en') {
+  const instance = i18n.createInstance()
+  instance.use(initReactI18next).init({
+    lng: lang,
+    fallbackLng: 'en',
+    resources: {
+      en: {
+        translation: {
+          categories: { names: { Food: 'Food', Transport: 'Transport' } },
+        },
+      },
+      ru: {
+        translation: {
+          categories: { names: { Food: 'Еда', Transport: 'Транспорт' } },
+        },
+      },
+    },
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+  })
+  return instance
+}
+
+function makeWrapper(instance: ReturnType<typeof buildI18n>) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <I18nextProvider i18n={instance}>{children}</I18nextProvider>
+  }
+}
+
+describe('useCategoryName', () => {
+  it('translates known category names', () => {
+    const wrapper = makeWrapper(buildI18n('en'))
+    const { result } = renderHook(() => useCategoryName(), { wrapper })
+    expect(result.current('Food')).toBe('Food')
+    expect(result.current('Transport')).toBe('Transport')
+  })
+
+  it('falls back to the input value when translation is missing', () => {
+    const wrapper = makeWrapper(buildI18n('en'))
+    const { result } = renderHook(() => useCategoryName(), { wrapper })
+    expect(result.current('Unknown')).toBe('Unknown')
+    expect(result.current('CustomCategory')).toBe('CustomCategory')
+  })
+
+  it('uses the active i18n language for translations', () => {
+    const wrapper = makeWrapper(buildI18n('ru'))
+    const { result } = renderHook(() => useCategoryName(), { wrapper })
+    expect(result.current('Food')).toBe('Еда')
+    expect(result.current('Transport')).toBe('Транспорт')
+  })
+
+  it('keeps the fallback identity even after switching languages', () => {
+    const wrapper = makeWrapper(buildI18n('ru'))
+    const { result } = renderHook(() => useCategoryName(), { wrapper })
+    expect(result.current('Mystery')).toBe('Mystery')
+  })
+})

--- a/web/src/shared/lib/expression.test.ts
+++ b/web/src/shared/lib/expression.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+
+import { evaluate, formatForInput, looksLikeExpression } from './expression'
+
+describe('looksLikeExpression', () => {
+  it.each([
+    ['1+2', true],
+    ['10*5', true],
+    ['100-20', true],
+    ['10×5', true],
+    ['10÷5', true],
+    ['200%', true],
+    ['(1+2)', true],
+    ['100', false],
+    ['1500.50', false],
+    ['', false],
+  ])('looksLikeExpression(%j) → %s', (input, expected) => {
+    expect(looksLikeExpression(input)).toBe(expected)
+  })
+})
+
+describe('evaluate — happy path', () => {
+  it('adds integers', () => {
+    expect(evaluate('1+2')).toEqual({ ok: true, value: 3 })
+  })
+
+  it('multiplies integers', () => {
+    expect(evaluate('2*3')).toEqual({ ok: true, value: 6 })
+  })
+
+  it('handles decimal numbers', () => {
+    expect(evaluate('1.5+2.5')).toEqual({ ok: true, value: 4 })
+  })
+
+  it('respects operator precedence (* before +)', () => {
+    expect(evaluate('2+3*4')).toEqual({ ok: true, value: 14 })
+  })
+
+  it('honours parentheses', () => {
+    expect(evaluate('(2+3)*4')).toEqual({ ok: true, value: 20 })
+  })
+
+  it('handles unary minus', () => {
+    expect(evaluate('-5+10')).toEqual({ ok: true, value: 5 })
+  })
+
+  it('replaces unicode × and ÷ with * and /', () => {
+    expect(evaluate('2×3÷6')).toEqual({ ok: true, value: 1 })
+  })
+
+  it('replaces unicode minus with ASCII', () => {
+    expect(evaluate('10−5')).toEqual({ ok: true, value: 5 })
+  })
+
+  it('treats comma as a decimal separator', () => {
+    expect(evaluate('1,5+0,5')).toEqual({ ok: true, value: 2 })
+  })
+
+  it('ignores whitespace', () => {
+    expect(evaluate(' 1 + 2 ')).toEqual({ ok: true, value: 3 })
+  })
+})
+
+describe('evaluate — percentage', () => {
+  it('treats a lone percent as a fraction', () => {
+    expect(evaluate('10%')).toEqual({ ok: true, value: 0.1 })
+  })
+
+  it('applies percentage of accumulator on +', () => {
+    expect(evaluate('200+10%')).toEqual({ ok: true, value: 220 })
+  })
+
+  it('applies percentage of accumulator on -', () => {
+    expect(evaluate('200-10%')).toEqual({ ok: true, value: 180 })
+  })
+})
+
+describe('evaluate — failure modes', () => {
+  it('rejects empty input', () => {
+    expect(evaluate('')).toEqual({ ok: false })
+  })
+
+  it('rejects input over MAX_LEN (64) chars', () => {
+    const long = '1+'.repeat(40) + '1'
+    expect(evaluate(long).ok).toBe(false)
+  })
+
+  it('rejects an operator without a right operand', () => {
+    expect(evaluate('1+')).toEqual({ ok: false })
+    expect(evaluate('1*2*')).toEqual({ ok: false })
+  })
+
+  it('rejects unbalanced parentheses', () => {
+    expect(evaluate('(1+2')).toEqual({ ok: false })
+  })
+
+  it('rejects a bare operator', () => {
+    expect(evaluate('+')).toEqual({ ok: false })
+  })
+
+  it('rejects two decimal points in one number', () => {
+    expect(evaluate('1.2.3')).toEqual({ ok: false })
+  })
+
+  it('rejects division by zero', () => {
+    expect(evaluate('1/0')).toEqual({ ok: false })
+  })
+
+  it('rejects results above MAX_VALUE (1e10)', () => {
+    expect(evaluate('99999999999')).toEqual({ ok: false })
+  })
+})
+
+describe('formatForInput', () => {
+  it('rounds to two decimals', () => {
+    expect(formatForInput(1.234)).toBe('1.23')
+    expect(formatForInput(1.236)).toBe('1.24')
+  })
+
+  it('drops trailing zeros via toString', () => {
+    expect(formatForInput(1.5)).toBe('1.5')
+    expect(formatForInput(2)).toBe('2')
+  })
+})

--- a/web/src/shared/lib/money.test.ts
+++ b/web/src/shared/lib/money.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  formatCents,
+  formatDate,
+  getCurrencySymbol,
+  getLocale,
+  parseCents,
+  sanitizeAmount,
+} from './money'
+
+describe('formatCents', () => {
+  it('formats USD with the narrow symbol', () => {
+    expect(formatCents(150050, 'USD')).toMatch(/\$1,500\.50/)
+  })
+
+  it('formats EUR with €', () => {
+    expect(formatCents(150050, 'EUR')).toMatch(/€1,500\.50/)
+  })
+
+  it('formats zero with two fraction digits', () => {
+    expect(formatCents(0, 'USD')).toMatch(/\$0\.00/)
+  })
+
+  it('uses minus prefix for negative amounts', () => {
+    expect(formatCents(-1500, 'USD')).toMatch(/-\$15\.00/)
+  })
+
+  it('always renders exactly two fraction digits', () => {
+    expect(formatCents(100, 'USD')).toMatch(/\$1\.00/)
+    expect(formatCents(105, 'USD')).toMatch(/\$1\.05/)
+  })
+
+  it('defaults to USD when currency is omitted', () => {
+    expect(formatCents(100)).toMatch(/\$1\.00/)
+  })
+})
+
+describe('parseCents', () => {
+  it('parses a clean decimal string', () => {
+    expect(parseCents('1500.50')).toBe(150050)
+  })
+
+  it('parses an integer string', () => {
+    expect(parseCents('100')).toBe(10000)
+  })
+
+  it('rounds to the nearest cent', () => {
+    expect(parseCents('0.005')).toBe(1)
+    expect(parseCents('0.004')).toBe(0)
+  })
+
+  it('strips non-numeric characters before parsing', () => {
+    expect(parseCents('$1500.50')).toBe(150050)
+  })
+
+  it('returns 0 for inputs that do not contain a number', () => {
+    expect(parseCents('abc')).toBe(0)
+    expect(parseCents('')).toBe(0)
+  })
+})
+
+describe('sanitizeAmount', () => {
+  it('keeps a clean decimal as-is', () => {
+    expect(sanitizeAmount('1500.50')).toBe('1500.50')
+  })
+
+  it('strips letters and other symbols', () => {
+    expect(sanitizeAmount('1a2.3b4')).toBe('12.34')
+  })
+
+  it('keeps only the first decimal point', () => {
+    expect(sanitizeAmount('1.2.3')).toBe('1.23')
+  })
+
+  it('limits the fractional part to two digits', () => {
+    expect(sanitizeAmount('1.2345')).toBe('1.23')
+  })
+
+  it('strips a leading zero unless followed by a dot', () => {
+    expect(sanitizeAmount('0123')).toBe('123')
+    expect(sanitizeAmount('0.5')).toBe('0.5')
+    expect(sanitizeAmount('0')).toBe('0')
+  })
+
+  it('returns an empty string for non-numeric input', () => {
+    expect(sanitizeAmount('abc')).toBe('')
+    expect(sanitizeAmount('')).toBe('')
+  })
+})
+
+describe('getCurrencySymbol', () => {
+  it('returns $ for USD', () => {
+    expect(getCurrencySymbol('USD')).toBe('$')
+  })
+
+  it('returns € for EUR', () => {
+    expect(getCurrencySymbol('EUR')).toBe('€')
+  })
+
+  it('returns the currency code for unknown codes', () => {
+    expect(getCurrencySymbol('XYZ')).toBe('XYZ')
+  })
+
+  it('defaults to USD when called with no argument', () => {
+    expect(getCurrencySymbol()).toBe('$')
+  })
+})
+
+describe('getLocale', () => {
+  it('maps known languages to BCP 47 locales', () => {
+    expect(getLocale('en')).toBe('en-US')
+    expect(getLocale('ru')).toBe('ru-RU')
+    expect(getLocale('uk')).toBe('uk-UA')
+    expect(getLocale('de')).toBe('de-DE')
+  })
+
+  it('falls back to en-US for unknown languages', () => {
+    expect(getLocale('xx')).toBe('en-US')
+    expect(getLocale('')).toBe('en-US')
+  })
+})
+
+describe('formatDate', () => {
+  it('formats Date objects with default options', () => {
+    const date = new Date('2026-04-28T12:00:00Z')
+    const result = formatDate(date, 'en')
+    expect(result).toMatch(/Apr/)
+    expect(result).toMatch(/28/)
+  })
+
+  it('accepts ISO strings', () => {
+    expect(formatDate('2026-04-28T12:00:00Z', 'en')).toMatch(/Apr/)
+  })
+
+  it('honours custom format options', () => {
+    const date = new Date('2026-04-28T12:00:00Z')
+    const result = formatDate(date, 'en', { year: 'numeric', month: 'long' })
+    expect(result).toContain('April')
+    expect(result).toContain('2026')
+  })
+})

--- a/web/src/shared/ui/AmountDisplay.test.tsx
+++ b/web/src/shared/ui/AmountDisplay.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { AmountDisplay } from './AmountDisplay'
+
+describe('AmountDisplay', () => {
+  it('renders the formatted amount with USD by default', () => {
+    render(<AmountDisplay cents={150050} />)
+    expect(screen.getByText(/\$1,500\.50/)).toBeInTheDocument()
+  })
+
+  it('uses the absolute value so negative cents render unsigned by default', () => {
+    render(<AmountDisplay cents={-150050} />)
+    const node = screen.getByText(/\$1,500\.50/)
+    expect(node.textContent ?? '').not.toContain('-')
+    expect(node.textContent ?? '').not.toContain('−')
+  })
+
+  it('renders a + prefix for income when showSign is on', () => {
+    render(<AmountDisplay cents={1000} type="income" showSign />)
+    const node = screen.getByText(/\$10\.00/)
+    expect(node.textContent?.startsWith('+')).toBe(true)
+  })
+
+  it('renders the unicode minus for expense when showSign is on', () => {
+    render(<AmountDisplay cents={1000} type="expense" showSign />)
+    const node = screen.getByText(/\$10\.00/)
+    expect(node.textContent?.startsWith('−')).toBe(true)
+  })
+
+  it('omits any sign prefix when showSign is off', () => {
+    render(<AmountDisplay cents={1000} type="income" showSign={false} />)
+    const node = screen.getByText(/\$10\.00/)
+    expect(node.textContent?.startsWith('+')).toBe(false)
+    expect(node.textContent?.startsWith('-')).toBe(false)
+    expect(node.textContent?.startsWith('−')).toBe(false)
+  })
+
+  it.each([
+    ['income', 'text-income'],
+    ['expense', 'text-expense'],
+    ['neutral', 'text-text'],
+  ] as const)('applies the colour class for type=%s', (type, cls) => {
+    render(<AmountDisplay cents={100} type={type} />)
+    const node = screen.getByText(/\$1\.00/)
+    expect(node.className).toContain(cls)
+  })
+
+  it.each([
+    ['sm', 'text-sm'],
+    ['md', 'text-base'],
+    ['lg', 'text-2xl'],
+    ['xl', 'text-4xl'],
+  ] as const)('applies the size class for size=%s', (size, cls) => {
+    render(<AmountDisplay cents={100} size={size} />)
+    const node = screen.getByText(/\$1\.00/)
+    expect(node.className).toContain(cls)
+  })
+
+  it('respects a non-USD currency prop', () => {
+    render(<AmountDisplay cents={1000} currency="EUR" />)
+    expect(screen.getByText(/€10\.00/)).toBeInTheDocument()
+  })
+
+  it('appends a custom className', () => {
+    render(<AmountDisplay cents={100} className="custom-class" />)
+    const node = screen.getByText(/\$1\.00/)
+    expect(node.className).toContain('custom-class')
+  })
+})

--- a/web/src/shared/ui/AmountInput.test.tsx
+++ b/web/src/shared/ui/AmountInput.test.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { AmountInput } from './AmountInput'
+
+interface ControlledProps {
+  initial?: string
+  onChange?: (value: string) => void
+  calculator?: boolean
+  currency?: string
+}
+
+function Controlled({ initial = '', onChange, calculator = true, currency = 'USD' }: ControlledProps) {
+  const [value, setValue] = useState(initial)
+  return (
+    <AmountInput
+      value={value}
+      onChange={(next) => {
+        setValue(next)
+        onChange?.(next)
+      }}
+      currency={currency}
+      calculator={calculator}
+    />
+  )
+}
+
+describe('AmountInput', () => {
+  it('renders the input with the placeholder and currency badge', () => {
+    render(<AmountInput value="" onChange={() => undefined} currency="USD" />)
+    expect(screen.getByPlaceholderText('0.00')).toBeInTheDocument()
+    expect(screen.getByText('$')).toBeInTheDocument()
+  })
+
+  it('strips letters but keeps operators when calculator=true', async () => {
+    const user = userEvent.setup()
+    const handle = vi.fn()
+    render(<Controlled onChange={handle} calculator={true} />)
+    await user.type(screen.getByPlaceholderText('0.00'), '1abc+2')
+    expect(handle).toHaveBeenLastCalledWith('1+2')
+  })
+
+  it('strips operators with calculator=false (strict sanitiser)', async () => {
+    const user = userEvent.setup()
+    const handle = vi.fn()
+    render(<Controlled onChange={handle} calculator={false} />)
+    await user.type(screen.getByPlaceholderText('0.00'), '1+2')
+    expect(handle).toHaveBeenLastCalledWith('12')
+  })
+
+  it('shows a preview when the value is a valid expression', () => {
+    render(<AmountInput value="1+2" onChange={() => undefined} currency="USD" />)
+    expect(screen.getByText(/= \$3\.00/)).toBeInTheDocument()
+  })
+
+  it('does not show a preview for plain numbers', () => {
+    render(<AmountInput value="100" onChange={() => undefined} currency="USD" />)
+    expect(screen.queryByText(/=/)).not.toBeInTheDocument()
+  })
+
+  it('commits the evaluated expression on Enter', async () => {
+    const user = userEvent.setup()
+    const handle = vi.fn()
+    render(<Controlled initial="1+2" onChange={handle} />)
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement
+    input.focus()
+    await user.keyboard('{Enter}')
+    expect(handle).toHaveBeenLastCalledWith('3')
+  })
+
+  it('commits the evaluated expression on blur', () => {
+    const handle = vi.fn()
+    render(<Controlled initial="1+2" onChange={handle} />)
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement
+    fireEvent.blur(input)
+    expect(handle).toHaveBeenLastCalledWith('3')
+  })
+
+  it('does not commit on Enter when expression is invalid', async () => {
+    const user = userEvent.setup()
+    const handle = vi.fn()
+    render(<Controlled initial="1+" onChange={handle} />)
+    const input = screen.getByPlaceholderText('0.00') as HTMLInputElement
+    input.focus()
+    await user.keyboard('{Enter}')
+    expect(handle).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/test/render.tsx
+++ b/web/src/test/render.tsx
@@ -1,0 +1,58 @@
+import type { ReactElement, ReactNode } from 'react'
+import { render, type RenderOptions } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { I18nextProvider, initReactI18next } from 'react-i18next'
+import i18n from 'i18next'
+import en from '../i18n/locales/en.json'
+
+function createTestI18n() {
+  const instance = i18n.createInstance()
+  instance.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: { en: { translation: en } },
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+  })
+  return instance
+}
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  })
+}
+
+interface ProviderOptions {
+  route?: string
+  queryClient?: QueryClient
+}
+
+export function renderWithProviders(
+  ui: ReactElement,
+  options: ProviderOptions & Omit<RenderOptions, 'wrapper'> = {},
+) {
+  const { route = '/', queryClient: providedClient, ...renderOptions } = options
+  const client = providedClient ?? createTestQueryClient()
+  const i18nInstance = createTestI18n()
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <I18nextProvider i18n={i18nInstance}>
+        <QueryClientProvider client={client}>
+          <MemoryRouter initialEntries={[route]}>{children}</MemoryRouter>
+        </QueryClientProvider>
+      </I18nextProvider>
+    )
+  }
+
+  return {
+    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+    queryClient: client,
+    i18n: i18nInstance,
+  }
+}

--- a/web/src/test/sanity.test.ts
+++ b/web/src/test/sanity.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+
+describe('test runner sanity', () => {
+  it('runs and asserts truthy results', () => {
+    expect(1 + 1).toBe(2)
+    expect('hello').toMatch(/ell/)
+  })
+})

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,117 @@
+import '@testing-library/jest-dom/vitest'
+import { afterEach, beforeEach, vi } from 'vitest'
+import { cleanup } from '@testing-library/react'
+import * as React from 'react'
+
+afterEach(() => {
+  cleanup()
+})
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+
+  ;(window as unknown as Record<string, unknown>).Telegram = {
+    WebApp: {
+      colorScheme: 'light',
+      contentSafeAreaInset: { top: 0 },
+      safeAreaInset: { top: 0 },
+      onEvent: vi.fn(),
+      offEvent: vi.fn(),
+      ready: vi.fn(),
+      expand: vi.fn(),
+      close: vi.fn(),
+      MainButton: { setText: vi.fn(), show: vi.fn(), hide: vi.fn(), onClick: vi.fn(), offClick: vi.fn() },
+      BackButton: { show: vi.fn(), hide: vi.fn(), onClick: vi.fn(), offClick: vi.fn() },
+      HapticFeedback: {
+        impactOccurred: vi.fn(),
+        notificationOccurred: vi.fn(),
+        selectionChanged: vi.fn(),
+      },
+      initDataUnsafe: { user: { id: 1, language_code: 'en' } },
+      initData: '',
+    },
+  }
+
+  window.localStorage.clear()
+  window.sessionStorage.clear()
+})
+
+vi.mock('@tma.js/sdk-react', () => ({
+  miniApp: { mount: vi.fn(), unmount: vi.fn() },
+  themeParams: { state: { value: {} } },
+  viewport: {
+    isStable: () => true,
+    isExpanded: () => true,
+    expand: vi.fn(),
+  },
+  backButton: {
+    isSupported: () => false,
+    show: vi.fn(),
+    hide: vi.fn(),
+    onClick: vi.fn(() => () => {}),
+  },
+  useSignal: () => undefined,
+  retrieveRawInitData: () => 'mock_init_data',
+}))
+
+const motionProps = new Set([
+  'initial', 'animate', 'exit', 'transition', 'variants',
+  'whileHover', 'whileTap', 'whileDrag', 'whileFocus', 'whileInView',
+  'drag', 'dragConstraints', 'dragElastic', 'dragMomentum', 'dragSnapToOrigin',
+  'dragListener', 'dragTransition', 'onDragStart', 'onDragEnd', 'onDrag',
+  'onAnimationStart', 'onAnimationComplete', 'onUpdate',
+  'layout', 'layoutId', 'layoutScroll', 'layoutDependency',
+  'viewport', 'custom',
+])
+
+function stripMotionProps(props: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(props)) {
+    if (!motionProps.has(k)) out[k] = v
+  }
+  return out
+}
+
+vi.mock('framer-motion', () => {
+  const motion = new Proxy(
+    {},
+    {
+      get(_target, key) {
+        if (typeof key !== 'string') return undefined
+        const tag = key
+        const Component = React.forwardRef<HTMLElement, Record<string, unknown>>((props, ref) => {
+          const { children, ...rest } = props
+          return React.createElement(tag, { ...stripMotionProps(rest), ref }, children as React.ReactNode)
+        })
+        Component.displayName = `motion.${tag}`
+        return Component
+      },
+    },
+  )
+
+  return {
+    motion,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+    LayoutGroup: ({ children }: { children: React.ReactNode }) => children,
+    useAnimation: () => ({ start: () => Promise.resolve(), stop: () => {}, set: () => {} }),
+    useMotionValue: (v: number) => ({ get: () => v, set: () => {}, on: () => () => {} }),
+    useTransform: () => ({ get: () => 0, set: () => {}, on: () => () => {} }),
+    useSpring: (v: number) => ({ get: () => v, set: () => {}, on: () => () => {} }),
+    useInView: () => true,
+    useScroll: () => ({ scrollY: { get: () => 0, on: () => () => {} } }),
+    animate: () => ({ stop: () => {} }),
+  }
+})

--- a/web/tsconfig.test.json
+++ b/web/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "verbatimModuleSyntax": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/test/**/*"
+  ]
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['node_modules', 'dist', 'src/main.tsx', 'src/mocks/**'],
+    css: false,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'html'],
+      reportsDirectory: './coverage',
+      include: ['src/**/*.{ts,tsx}'],
+      exclude: [
+        'src/**/*.{test,spec}.{ts,tsx}',
+        'src/**/*.d.ts',
+        'src/main.tsx',
+        'src/mocks/**',
+        'src/test/**',
+        'src/i18n/**',
+        'src/vite-env.d.ts',
+      ],
+    },
+  },
+})


### PR DESCRIPTION
Closes #42

## Что сделано

Подняли тестовую инфраструктуру и закрыли самые болезненные пробелы. «Полное покрытие» в один PR не вписывается без потери ревью-качества, поэтому разбили на foundation/critical/roadmap.

### Foundation (Phase 0)
- Frontend: vitest 2.1 + @testing-library/react 16 + jsdom 26 + setup-файл (моки `window.Telegram`, `matchMedia`, `@tma.js/sdk-react`, `framer-motion`) + `renderWithProviders` (QueryClient, MemoryRouter, in-memory i18next).
- npm scripts: `test`, `test:watch`, `test:coverage` (v8 provider, lcov + html).
- Makefile: `test-cover` (Go coverage profile), `web-test`.
- CI: web-build job теперь поднимает vitest+coverage и аплоадит artifact; unit-tests job получил `-coverprofile` + artifact.
- README: задокументированы все тестовые команды и расширенный local CI gate.

### Frontend reference tests (Phase 1) — 8 файлов, 107 кейсов
- `shared/lib/money.test.ts` (26): formatCents, parseCents, sanitizeAmount, getCurrencySymbol, getLocale, formatDate.
- `shared/lib/expression.test.ts` (33): evaluate happy/percentage/failures, formatForInput, looksLikeExpression.
- `shared/api/client.test.ts` (12): 200/204/4xx/5xx, X-Telegram-Init-Data, abort timeout (15s) на vi.useFakeTimers, все verbs.
- `shared/api/transactions.test.ts` (7): URL-сборка, payload mapping, vi.mock на `./client`.
- `shared/hooks/useCategoryName.test.tsx` (4): renderHook + i18n provider, fallback на identity, переключение языка.
- `shared/ui/AmountDisplay.test.tsx` (14): props → DOM, sign prefixes, type/size классы, currency.
- `shared/ui/AmountInput.test.tsx` (8): user-event ввод, Enter/blur коммит выражения, проверка sanitised onChange.
- `features/add-transaction/index.test.tsx` (2): smoke-render с моками всех api/hooks + полный submit flow до transactionsApi.create.

### Backend critical gaps (Phase 2) — 11 файлов
- **Integration infra**: `internal/testutil/db.go` (OpenTestPool читает `TEST_DATABASE_URL`/`DATABASE_URL`, иначе t.Skip; CleanupTables бережно сохраняет системные категории) + `db_seed.go` (SeedUser/SeedAccount/SeedCategory). Тег `//go:build integration`.
- **Repository integration tests** (3 файла, 17 кейсов): `transaction_test.go`, `account_test.go`, `category_test.go`. CRUD, scoping by user, FK/защита chains.
- **Service unit tests**: `admin_test.go` (clamp pagination, retention math, cohort=0 fallback), `stats_test.go` (passthrough + PeriodRange для today/week/month/lastweek/lastmonth/3months + ErrInvalidPeriod), `export_test.go` (CSV header-only/with rows/stop on out-of-range/error).
- **API handler unit tests**: `balance_test.go` (агрегация по валюте, фильтр account_id, fallback на USD, 405), `stats_test.go` (default period=month, custom date range, 400 на invalid, account_id вариант), `adjustment_test.go` (POST с positive/negative delta, 400 на invalid JSON и zero delta, 405).
- **Domain**: `account_test.go` (AccountType enum guard), `transaction_test.go` (TransactionType enum), `transfer_test.go` (FromTxID/ToTxID nullable invariant), `currency_test.go` (ValidCurrency, SearchCurrencies code/name passes, capping at 5).

### Что НЕ вошло — follow-ups

После мерджа открываем 12 точечных issue для систематического дальнейшего покрытия:

- **#42a** — Repository integration: оставшиеся 9 (admin, budget, db pool, exchange_snapshot, pgconv unit, recurring, savings_goal, transfer, user).
- **#42b** — API handlers: остатки (adjustment service-level, default_categories, server, user). `savings_goal` уже в `goals_test.go`.
- **#42c** — Service: rateapi, snapshot.
- **#42d** — Telegram bot handlers (`internal/handler/`: i18n, middleware, router, start).
- **#42e** — Domain: errors, exchange_snapshot.
- **#42f** — Frontend hooks: 6 оставшихся (useAnimateNumbers, useBaseCurrency, useFirstLaunchSetup, useHaptic, useMainButton, useTelegramApp).
- **#42g** — Frontend UI: ~22 компонента (с локальными моками framer-motion для animation-чувствительных).
- **#42h** — Frontend features: 13 фич deep-coverage.
- **#42i** — Frontend api services: 12 оставшихся (accounts, admin, balance, budgets, categories, export, goals, recurring, settings, stats, transfers).
- **#42j** — E2E с Playwright (create transaction, transfer, budget, goal flows).
- **#42k** — Coverage thresholds в CI (≥80% lines / ≥70% branches на оба слоя).
- **#42l** — `internal/{config,notify,scheduler}` (нужны фейки для SMTP/cron).
- **#42m** — Включить `npm run lint` в CI после починки 12 уже существующих eslint-ошибок в `features/stats/index.tsx`, `shared/lib/categoryIcons.tsx`, `shared/ui/DatePicker.tsx` (поэтому `npm run lint` пока не в job web-build).

## Как проверить

```bash
# Backend
make lint            # 0 issues
make vuln            # 0 vulns
make test-unit       # все unit-тесты
make test-cover      # с coverage профилем
# integration: требует поднятого postgres + DATABASE_URL
make test-integration

# Frontend
cd web && npm ci
npm run build        # tsc -b + vite build, проходит
npm run test         # vitest run → 107 passed
npm run test:coverage # + html/lcov в web/coverage/
```

Production-логика не менялась — только тестовая инфраструктура, конфиги CI/Make, и мелкое расширение `internal/api/export_test.go` (test-only shim для balance/stats/adjustment handlers).