### PR TITLE
test(#43): full coverage of remaining backend and frontend layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,10 @@ jobs:
         working-directory: web
         run: npm ci
 
+      - name: Lint Mini App
+        working-directory: web
+        run: npm run lint
+
       - name: Run Mini App tests with coverage
         working-directory: web
         run: npm run test:coverage

--- a/internal/api/default_categories_test.go
+++ b/internal/api/default_categories_test.go
@@ -1,0 +1,54 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/horexdev/money-tracker/internal/api"
+	"github.com/horexdev/money-tracker/internal/domain"
+)
+
+func TestDefaultCategoriesFor_KnownLanguage(t *testing.T) {
+	en := api.DefaultCategoriesFor("en")
+	assert.NotEmpty(t, en)
+	// One of the seeds must be the savings category.
+	hasSavings := false
+	for _, s := range en {
+		if s.Type == domain.CategoryTypeSavings {
+			hasSavings = true
+			break
+		}
+	}
+	assert.True(t, hasSavings, "every locale must include a savings seed")
+}
+
+func TestDefaultCategoriesFor_FallsBackToEnglish(t *testing.T) {
+	en := api.DefaultCategoriesFor("en")
+	zz := api.DefaultCategoriesFor("zz") // unknown locale
+	assert.Equal(t, en, zz, "unknown locale should fall back to English seeds")
+}
+
+func TestDefaultCategoriesFor_AllLocalesHaveSameLength(t *testing.T) {
+	enLen := len(api.DefaultCategoriesFor("en"))
+	for _, lang := range []string{"ru", "uk", "be", "kk", "uz", "es", "de", "it", "fr", "pt", "nl", "ar", "tr", "ko", "ms", "id"} {
+		got := api.DefaultCategoriesFor(lang)
+		assert.Lenf(t, got, enLen, "locale %q must define same number of seeds as English", lang)
+	}
+}
+
+func TestDefaultCategoriesFor_AllLocalesShareIcons(t *testing.T) {
+	en := api.DefaultCategoriesFor("en")
+	for _, lang := range []string{"ru", "uk", "es", "de", "fr"} {
+		got := api.DefaultCategoriesFor(lang)
+		require := len(en) == len(got)
+		if !require {
+			continue
+		}
+		for i := range en {
+			assert.Equalf(t, en[i].Icon, got[i].Icon, "icon mismatch at %d in %q", i, lang)
+			assert.Equalf(t, en[i].Type, got[i].Type, "type mismatch at %d in %q", i, lang)
+			assert.Equalf(t, en[i].Color, got[i].Color, "color mismatch at %d in %q", i, lang)
+		}
+	}
+}

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -122,6 +122,14 @@ func AdjustAccountHandlerForTest(svc AdjustmentApplier, log *slog.Logger, accoun
 	return adjustAccountHandler(svc, log, accountID)
 }
 
+// UserDataHandlerForTest exposes userDataHandler for testing.
+func UserDataHandlerForTest(userSvc *service.UserService, log *slog.Logger) http.HandlerFunc {
+	return userDataHandler(userSvc, log)
+}
+
+// DefaultCategoriesFor exposes defaultCategoriesFor for tests.
+var DefaultCategoriesFor = defaultCategoriesFor
+
 // TelegramUserForTest constructs a TelegramUser for use in tests.
 func TelegramUserForTest(id int64, firstName, langCode string) TelegramUser {
 	return TelegramUser{ID: id, FirstName: firstName, LanguageCode: langCode}

--- a/internal/api/user_test.go
+++ b/internal/api/user_test.go
@@ -1,0 +1,59 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/horexdev/money-tracker/internal/api"
+	"github.com/horexdev/money-tracker/internal/service"
+	"github.com/horexdev/money-tracker/internal/testutil"
+	"github.com/horexdev/money-tracker/internal/testutil/mocks"
+)
+
+func buildUserDataHandler(repo *mocks.MockUserStorer) http.HandlerFunc {
+	log := testutil.TestLogger()
+	userSvc := service.NewUserService(repo, log)
+	return api.UserDataHandlerForTest(userSvc, log)
+}
+
+func newAuthedUserRequest(method string) *http.Request {
+	r := httptest.NewRequest(method, "/api/v1/user/data", nil)
+	return r.WithContext(api.WithUserID(context.Background(), 1))
+}
+
+func TestUserDataHandler_DELETE_Success(t *testing.T) {
+	repo := &mocks.MockUserStorer{}
+	repo.On("ResetData", mock.Anything, int64(1)).Return(nil)
+
+	h := buildUserDataHandler(repo)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAuthedUserRequest(http.MethodDelete))
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	repo.AssertExpectations(t)
+}
+
+func TestUserDataHandler_NonDELETE_Returns405(t *testing.T) {
+	h := buildUserDataHandler(&mocks.MockUserStorer{})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAuthedUserRequest(http.MethodGet))
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+}
+
+func TestUserDataHandler_PropagatesServiceError(t *testing.T) {
+	repo := &mocks.MockUserStorer{}
+	repo.On("ResetData", mock.Anything, int64(1)).Return(errors.New("db down"))
+
+	h := buildUserDataHandler(repo)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, newAuthedUserRequest(http.MethodDelete))
+
+	assert.GreaterOrEqual(t, w.Code, 400)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,106 @@
+package config_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/config"
+)
+
+// setEnv sets multiple env vars for the test and restores them on cleanup.
+func setEnv(t *testing.T, kv map[string]string) {
+	t.Helper()
+	for k, v := range kv {
+		t.Setenv(k, v)
+	}
+}
+
+// Aliases that allow the test to unset env vars (which testing.T.Setenv does
+// not support) while still using a single import line.
+var (
+	osLookupEnv = os.LookupEnv
+	osUnsetenv  = os.Unsetenv
+	osSetenv    = os.Setenv
+)
+
+func TestLoad_RequiredFields(t *testing.T) {
+	setEnv(t, map[string]string{
+		"BOT_TOKEN":    "tok",
+		"DATABASE_URL": "postgres://x",
+		"REDIS_URL":    "redis://y",
+	})
+	cfg, err := config.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "tok", cfg.BotToken)
+	assert.Equal(t, "postgres://x", cfg.DatabaseURL)
+	assert.Equal(t, "redis://y", cfg.RedisURL)
+}
+
+func TestLoad_AppliesDefaults(t *testing.T) {
+	setEnv(t, map[string]string{
+		"BOT_TOKEN":    "tok",
+		"DATABASE_URL": "postgres://x",
+		"REDIS_URL":    "redis://y",
+	})
+	cfg, err := config.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "info", cfg.LogLevel)
+	assert.Equal(t, "db/migrations", cfg.MigrationsDir)
+	assert.Equal(t, time.Hour, cfg.ExchangeRateTTL)
+	assert.Equal(t, "8080", cfg.APIPort)
+	assert.Equal(t, "*", cfg.AllowedOrigins)
+	assert.Empty(t, cfg.MiniAppURL)
+	assert.Equal(t, int64(0), cfg.AdminUserID)
+	assert.False(t, cfg.DevMode)
+	assert.Equal(t, "en", cfg.DevLang)
+}
+
+func TestLoad_OverridesDefaults(t *testing.T) {
+	setEnv(t, map[string]string{
+		"BOT_TOKEN":         "tok",
+		"DATABASE_URL":      "postgres://x",
+		"REDIS_URL":         "redis://y",
+		"LOG_LEVEL":         "debug",
+		"MIGRATIONS_DIR":    "/tmp/migrations",
+		"EXCHANGE_RATE_TTL": "30m",
+		"API_PORT":          "9090",
+		"ALLOWED_ORIGINS":   "https://app.example.com",
+		"MINI_APP_URL":      "https://t.me/app",
+		"ADMIN_USER_ID":     "12345",
+		"DEV_MODE":          "true",
+		"DEV_LANG":          "ru",
+	})
+	cfg, err := config.Load()
+	require.NoError(t, err)
+	assert.Equal(t, "debug", cfg.LogLevel)
+	assert.Equal(t, "/tmp/migrations", cfg.MigrationsDir)
+	assert.Equal(t, 30*time.Minute, cfg.ExchangeRateTTL)
+	assert.Equal(t, "9090", cfg.APIPort)
+	assert.Equal(t, "https://app.example.com", cfg.AllowedOrigins)
+	assert.Equal(t, "https://t.me/app", cfg.MiniAppURL)
+	assert.Equal(t, int64(12345), cfg.AdminUserID)
+	assert.True(t, cfg.DevMode)
+	assert.Equal(t, "ru", cfg.DevLang)
+}
+
+func TestLoad_ErrorsOnMissingRequired(t *testing.T) {
+	saved := map[string]string{}
+	for _, k := range []string{"BOT_TOKEN", "DATABASE_URL", "REDIS_URL"} {
+		if v, ok := osLookupEnv(k); ok {
+			saved[k] = v
+		}
+		osUnsetenv(k)
+	}
+	t.Cleanup(func() {
+		for k, v := range saved {
+			osSetenv(k, v)
+		}
+	})
+
+	_, err := config.Load()
+	assert.Error(t, err)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -93,11 +93,11 @@ func TestLoad_ErrorsOnMissingRequired(t *testing.T) {
 		if v, ok := osLookupEnv(k); ok {
 			saved[k] = v
 		}
-		osUnsetenv(k)
+		require.NoError(t, osUnsetenv(k))
 	}
 	t.Cleanup(func() {
 		for k, v := range saved {
-			osSetenv(k, v)
+			_ = osSetenv(k, v)
 		}
 	})
 

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -1,0 +1,95 @@
+package domain_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+)
+
+// TestSentinelErrors_AreDistinct guards against accidental duplication of
+// sentinel errors — two errors must never be `errors.Is`-equal.
+func TestSentinelErrors_AreDistinct(t *testing.T) {
+	all := []error{
+		domain.ErrUserNotFound,
+		domain.ErrCategoryNotFound,
+		domain.ErrTransactionNotFound,
+		domain.ErrBudgetNotFound,
+		domain.ErrRecurringNotFound,
+		domain.ErrGoalNotFound,
+		domain.ErrInvalidAmount,
+		domain.ErrInvalidPeriod,
+		domain.ErrInvalidCurrency,
+		domain.ErrInvalidFrequency,
+		domain.ErrInvalidLanguage,
+		domain.ErrTooManyDisplayCurrencies,
+		domain.ErrExchangeRateUnavailable,
+		domain.ErrCategoryNameEmpty,
+		domain.ErrCategoryInUse,
+		domain.ErrCategorySystemReadOnly,
+		domain.ErrInsufficientGoalFunds,
+		domain.ErrBudgetAlreadyExists,
+		domain.ErrAccountNotFound,
+		domain.ErrDefaultAccountExists,
+		domain.ErrAccountHasTransactions,
+		domain.ErrAccountHasTransfers,
+		domain.ErrAccountHasRecurring,
+		domain.ErrCannotDeleteLastAccount,
+		domain.ErrMustSetNewDefault,
+		domain.ErrCurrencyImmutable,
+		domain.ErrTransferSameAccount,
+		domain.ErrAdjustmentZeroAmount,
+		domain.ErrCategoryProtected,
+		domain.ErrInvalidSortParam,
+	}
+	for i, a := range all {
+		for j, b := range all {
+			if i == j {
+				continue
+			}
+			assert.Falsef(t, errors.Is(a, b), "%v must not be Is-equal to %v", a, b)
+		}
+	}
+}
+
+// TestSentinelErrors_HaveNonEmptyMessages ensures every public error carries
+// a human-readable message — empty messages cause confusing API responses.
+func TestSentinelErrors_HaveNonEmptyMessages(t *testing.T) {
+	all := []error{
+		domain.ErrUserNotFound,
+		domain.ErrCategoryNotFound,
+		domain.ErrTransactionNotFound,
+		domain.ErrBudgetNotFound,
+		domain.ErrRecurringNotFound,
+		domain.ErrGoalNotFound,
+		domain.ErrInvalidAmount,
+		domain.ErrInvalidPeriod,
+		domain.ErrInvalidCurrency,
+		domain.ErrInvalidFrequency,
+		domain.ErrInvalidLanguage,
+		domain.ErrTooManyDisplayCurrencies,
+		domain.ErrExchangeRateUnavailable,
+		domain.ErrCategoryNameEmpty,
+		domain.ErrCategoryInUse,
+		domain.ErrCategorySystemReadOnly,
+		domain.ErrInsufficientGoalFunds,
+		domain.ErrBudgetAlreadyExists,
+		domain.ErrAccountNotFound,
+		domain.ErrDefaultAccountExists,
+		domain.ErrAccountHasTransactions,
+		domain.ErrAccountHasTransfers,
+		domain.ErrAccountHasRecurring,
+		domain.ErrCannotDeleteLastAccount,
+		domain.ErrMustSetNewDefault,
+		domain.ErrCurrencyImmutable,
+		domain.ErrTransferSameAccount,
+		domain.ErrAdjustmentZeroAmount,
+		domain.ErrCategoryProtected,
+		domain.ErrInvalidSortParam,
+	}
+	for _, e := range all {
+		assert.NotEmpty(t, e.Error(), "error must have a non-empty message")
+	}
+}

--- a/internal/domain/exchange_snapshot_test.go
+++ b/internal/domain/exchange_snapshot_test.go
@@ -1,0 +1,34 @@
+package domain_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+)
+
+func TestExchangeRateSnapshot_ZeroValue(t *testing.T) {
+	var snap domain.ExchangeRateSnapshot
+	assert.Zero(t, snap.ID)
+	assert.True(t, snap.SnapshotDate.IsZero())
+	assert.Empty(t, snap.BaseCurrency)
+	assert.Empty(t, snap.TargetCurrency)
+	assert.Zero(t, snap.Rate)
+}
+
+func TestExchangeRateSnapshot_AssignAllFields(t *testing.T) {
+	snap := domain.ExchangeRateSnapshot{
+		ID:             1,
+		SnapshotDate:   time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		BaseCurrency:   "USD",
+		TargetCurrency: "EUR",
+		Rate:           0.92,
+		CreatedAt:      time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+	}
+	assert.Equal(t, int64(1), snap.ID)
+	assert.Equal(t, "USD", snap.BaseCurrency)
+	assert.Equal(t, "EUR", snap.TargetCurrency)
+	assert.InDelta(t, 0.92, snap.Rate, 0.0001)
+}

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -1,0 +1,112 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-telegram/bot/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/service"
+	"github.com/horexdev/money-tracker/internal/testutil"
+	"github.com/horexdev/money-tracker/internal/testutil/mocks"
+)
+
+func TestGetString_KnownLanguage(t *testing.T) {
+	en := getString(domain.LangEN)
+	assert.NotEmpty(t, en.welcome, "english welcome must be defined")
+	assert.NotEmpty(t, en.help)
+	assert.NotEmpty(t, en.openButton)
+
+	ru := getString(domain.LangRU)
+	assert.NotEqual(t, en.welcome, ru.welcome, "russian welcome must differ from english")
+}
+
+func TestGetString_FallsBackToEnglish(t *testing.T) {
+	en := getString(domain.LangEN)
+	got := getString(domain.Language("xx"))
+	assert.Equal(t, en, got)
+}
+
+func TestGetString_AllSupportedLanguagesPresent(t *testing.T) {
+	supported := []domain.Language{
+		domain.LangEN, domain.LangRU, domain.LangUK, domain.LangBE, domain.LangKK,
+		domain.LangUZ, domain.LangES, domain.LangDE, domain.LangIT, domain.LangFR,
+		domain.LangPT, domain.LangNL, domain.LangAR, domain.LangTR, domain.LangKO,
+		domain.LangMS, domain.LangID,
+	}
+	english := getString(domain.LangEN)
+	for _, lang := range supported {
+		s := getString(lang)
+		assert.NotEmptyf(t, s.welcome, "lang %q welcome empty", lang)
+		assert.NotEmptyf(t, s.help, "lang %q help empty", lang)
+		assert.NotEmptyf(t, s.openButton, "lang %q openButton empty", lang)
+		// EN fallback path returns english struct exactly only for invalid lang;
+		// every supported lang must override at least the welcome string.
+		if lang != domain.LangEN {
+			assert.NotEqualf(t, english.welcome, s.welcome, "lang %q must localise welcome", lang)
+		}
+	}
+}
+
+func TestExtractTelegramUser_Message(t *testing.T) {
+	user := &models.User{ID: 42, FirstName: "Alice"}
+	upd := &models.Update{Message: &models.Message{From: user}}
+	got := extractTelegramUser(upd)
+	assert.Equal(t, user, got)
+}
+
+func TestExtractTelegramUser_CallbackQuery(t *testing.T) {
+	upd := &models.Update{
+		CallbackQuery: &models.CallbackQuery{From: models.User{ID: 100, FirstName: "Bob"}},
+	}
+	got := extractTelegramUser(upd)
+	assert.Equal(t, int64(100), got.ID)
+	assert.Equal(t, "Bob", got.FirstName)
+}
+
+func TestExtractTelegramUser_NilCases(t *testing.T) {
+	assert.Nil(t, extractTelegramUser(&models.Update{}))
+	assert.Nil(t, extractTelegramUser(&models.Update{Message: &models.Message{}}))
+	assert.Nil(t, extractTelegramUser(&models.Update{CallbackQuery: &models.CallbackQuery{}}))
+}
+
+func TestExtractUserID(t *testing.T) {
+	assert.Equal(t, int64(0), extractUserID(&models.Update{}))
+	assert.Equal(t, int64(7), extractUserID(&models.Update{
+		Message: &models.Message{From: &models.User{ID: 7}},
+	}))
+	assert.Equal(t, int64(99), extractUserID(&models.Update{
+		CallbackQuery: &models.CallbackQuery{From: models.User{ID: 99}},
+	}))
+}
+
+func TestUserLang_FallsBackOnError(t *testing.T) {
+	repo := &mocks.MockUserStorer{}
+	repo.On("GetByID", mock.Anything, int64(1)).Return(nil, errors.New("not found"))
+	svc := service.NewUserService(repo, testutil.TestLogger())
+
+	got := userLang(context.Background(), svc, 1)
+	assert.Equal(t, domain.LangEN, got)
+}
+
+func TestUserLang_FallsBackOnEmptyLanguage(t *testing.T) {
+	repo := &mocks.MockUserStorer{}
+	repo.On("GetByID", mock.Anything, int64(2)).Return(&domain.User{ID: 2, Language: ""}, nil)
+	svc := service.NewUserService(repo, testutil.TestLogger())
+
+	got := userLang(context.Background(), svc, 2)
+	assert.Equal(t, domain.LangEN, got)
+}
+
+func TestUserLang_ReturnsStoredLanguage(t *testing.T) {
+	repo := &mocks.MockUserStorer{}
+	repo.On("GetByID", mock.Anything, int64(3)).Return(&domain.User{ID: 3, Language: domain.LangRU}, nil)
+	svc := service.NewUserService(repo, testutil.TestLogger())
+
+	got := userLang(context.Background(), svc, 3)
+	assert.Equal(t, domain.LangRU, got)
+}

--- a/internal/notify/telegram_test.go
+++ b/internal/notify/telegram_test.go
@@ -1,0 +1,74 @@
+package notify
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTranslateCategory_KnownLanguageAndKey(t *testing.T) {
+	assert.Equal(t, "Еда", translateCategory("ru", "Food"))
+	assert.Equal(t, "Транспорт", translateCategory("ru", "Transport"))
+	assert.Equal(t, "Comida", translateCategory("es", "Food"))
+}
+
+func TestTranslateCategory_UnknownLanguageFallsBack(t *testing.T) {
+	// Unknown lang returns the English key as-is.
+	assert.Equal(t, "Food", translateCategory("xx", "Food"))
+}
+
+func TestTranslateCategory_UnknownKeyReturnsKey(t *testing.T) {
+	// Known lang, unknown key — return key (English fallback).
+	assert.Equal(t, "Custom", translateCategory("ru", "Custom"))
+}
+
+func TestAlertEmoji_BoundaryValues(t *testing.T) {
+	cases := []struct {
+		percent int
+		want    string
+	}{
+		{0, "🟢"},
+		{50, "🟢"},
+		{74, "🟢"},
+		{75, "🟡"},
+		{94, "🟡"},
+		{95, "🟠"},
+		{99, "🟠"},
+		{100, "🔴"},
+		{200, "🔴"},
+	}
+	for _, c := range cases {
+		assert.Equalf(t, c.want, alertEmoji(c.percent), "percent=%d", c.percent)
+	}
+}
+
+func TestFormatMoney(t *testing.T) {
+	assert.Equal(t, "10.00 USD", formatMoney(1000, "USD"))
+	assert.Equal(t, "12.34 EUR", formatMoney(1234, "EUR"))
+	assert.Equal(t, "0.05 USD", formatMoney(5, "USD"))
+}
+
+func TestFormatMoney_NegativeCents(t *testing.T) {
+	// Negative cents render as a negative whole part with positive fractional digits.
+	got := formatMoney(-1234, "USD")
+	assert.Equal(t, "-12.34 USD", got)
+}
+
+func TestBudgetAlertTexts_AllLanguagesHaveFourEntries(t *testing.T) {
+	for lang, labels := range budgetAlertTexts {
+		assert.NotEmpty(t, labels[0], "lang %q title", lang)
+		assert.NotEmpty(t, labels[1], "lang %q category label", lang)
+		assert.NotEmpty(t, labels[2], "lang %q spent label", lang)
+		assert.NotEmpty(t, labels[3], "lang %q remaining label", lang)
+	}
+}
+
+func TestCategoryNames_EveryLocaleCoversBaselineKeys(t *testing.T) {
+	en := categoryNames["en"]
+	for lang, names := range categoryNames {
+		for key := range en {
+			_, ok := names[key]
+			assert.Truef(t, ok, "lang %q missing translation for %q", lang, key)
+		}
+	}
+}

--- a/internal/repository/admin_test.go
+++ b/internal/repository/admin_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/repository"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+func newAdminRepoFixtures(t *testing.T) (*repository.AdminRepository, func() int64) {
+	t.Helper()
+	pool := testutil.OpenTestPool(t)
+	testutil.CleanupTables(t, pool)
+	t.Cleanup(func() { testutil.CleanupTables(t, pool) })
+
+	seq := time.Now().UnixNano()
+	next := func() int64 {
+		seq++
+		return seq
+	}
+	return repository.NewAdminRepository(pool), next
+}
+
+func TestAdminRepository_CountUsers_EmptyAndAfterSeed(t *testing.T) {
+	repo, next := newAdminRepoFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	ctx := context.Background()
+
+	n, err := repo.CountUsers(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	testutil.SeedUser(t, pool, next())
+	testutil.SeedUser(t, pool, next())
+	testutil.SeedUser(t, pool, next())
+
+	n, err = repo.CountUsers(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+}
+
+func TestAdminRepository_ListUsers_Pagination(t *testing.T) {
+	repo, next := newAdminRepoFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		testutil.SeedUser(t, pool, next())
+	}
+
+	page1, err := repo.ListUsers(ctx, 2, 0)
+	require.NoError(t, err)
+	assert.Len(t, page1, 2)
+
+	page2, err := repo.ListUsers(ctx, 2, 2)
+	require.NoError(t, err)
+	assert.Len(t, page2, 2)
+
+	page3, err := repo.ListUsers(ctx, 2, 4)
+	require.NoError(t, err)
+	assert.Len(t, page3, 1)
+}
+
+func TestAdminRepository_ListAllUserIDs(t *testing.T) {
+	repo, next := newAdminRepoFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	ctx := context.Background()
+
+	id1 := next()
+	id2 := next()
+	testutil.SeedUser(t, pool, id1)
+	testutil.SeedUser(t, pool, id2)
+
+	ids, err := repo.ListAllUserIDs(ctx)
+	require.NoError(t, err)
+	assert.Len(t, ids, 2)
+	assert.Contains(t, ids, id1)
+	assert.Contains(t, ids, id2)
+}
+
+func TestAdminRepository_CountNewUsers_RespectsRange(t *testing.T) {
+	repo, next := newAdminRepoFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	ctx := context.Background()
+
+	testutil.SeedUser(t, pool, next())
+	testutil.SeedUser(t, pool, next())
+
+	from := time.Now().Add(-time.Hour)
+	to := time.Now().Add(time.Hour)
+	n, err := repo.CountNewUsers(ctx, from, to)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+
+	// Range that does not include the seeded users
+	pastFrom := time.Now().Add(-48 * time.Hour)
+	pastTo := time.Now().Add(-24 * time.Hour)
+	n, err = repo.CountNewUsers(ctx, pastFrom, pastTo)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}

--- a/internal/repository/budget_test.go
+++ b/internal/repository/budget_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/repository"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+func newBudgetRepoFixtures(t *testing.T) (*repository.BudgetRepository, int64, int64) {
+	t.Helper()
+	pool := testutil.OpenTestPool(t)
+	testutil.CleanupTables(t, pool)
+	t.Cleanup(func() { testutil.CleanupTables(t, pool) })
+
+	userID := testutil.SeedUser(t, pool, time.Now().UnixNano())
+	categoryID := testutil.SeedCategory(t, pool, userID, "Food", "expense")
+	return repository.NewBudgetRepository(pool), userID, categoryID
+}
+
+func TestBudgetRepository_Create_PersistsAttributes(t *testing.T) {
+	repo, userID, categoryID := newBudgetRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Budget{
+		UserID:               userID,
+		CategoryID:           categoryID,
+		LimitCents:           50000,
+		Period:               domain.BudgetPeriodMonthly,
+		CurrencyCode:         "USD",
+		NotifyAtPercent:      80,
+		NotificationsEnabled: true,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+	assert.Equal(t, int64(50000), created.LimitCents)
+	assert.Equal(t, domain.BudgetPeriodMonthly, created.Period)
+	assert.Equal(t, 80, created.NotifyAtPercent)
+	assert.True(t, created.NotificationsEnabled)
+}
+
+func TestBudgetRepository_GetByID_NotFound(t *testing.T) {
+	repo, userID, _ := newBudgetRepoFixtures(t)
+	_, err := repo.GetByID(context.Background(), 99_999, userID)
+	assert.ErrorIs(t, err, domain.ErrBudgetNotFound)
+}
+
+func TestBudgetRepository_ListByUser_OnlyOwnBudgets(t *testing.T) {
+	repo, user1, cat1 := newBudgetRepoFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	user2 := testutil.SeedUser(t, pool, time.Now().UnixNano()+1)
+	cat2 := testutil.SeedCategory(t, pool, user2, "Travel", "expense")
+
+	ctx := context.Background()
+	_, err := repo.Create(ctx, &domain.Budget{
+		UserID: user1, CategoryID: cat1, LimitCents: 10000,
+		Period: domain.BudgetPeriodMonthly, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+	_, err = repo.Create(ctx, &domain.Budget{
+		UserID: user2, CategoryID: cat2, LimitCents: 20000,
+		Period: domain.BudgetPeriodMonthly, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	list, err := repo.ListByUser(ctx, user1)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, user1, list[0].UserID)
+}
+
+func TestBudgetRepository_Update(t *testing.T) {
+	repo, userID, categoryID := newBudgetRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Budget{
+		UserID: userID, CategoryID: categoryID, LimitCents: 10000,
+		Period: domain.BudgetPeriodMonthly, CurrencyCode: "USD", NotifyAtPercent: 50,
+	})
+	require.NoError(t, err)
+
+	updated, err := repo.Update(ctx, &domain.Budget{
+		ID:              created.ID,
+		UserID:          userID,
+		CategoryID:      categoryID,
+		LimitCents:      30000,
+		Period:          domain.BudgetPeriodWeekly,
+		NotifyAtPercent: 90,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(30000), updated.LimitCents)
+	assert.Equal(t, 90, updated.NotifyAtPercent)
+}
+
+func TestBudgetRepository_Delete(t *testing.T) {
+	repo, userID, categoryID := newBudgetRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Budget{
+		UserID: userID, CategoryID: categoryID, LimitCents: 1000,
+		Period: domain.BudgetPeriodMonthly, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Delete(ctx, created.ID, userID))
+	_, err = repo.GetByID(ctx, created.ID, userID)
+	assert.ErrorIs(t, err, domain.ErrBudgetNotFound)
+}
+
+func TestBudgetRepository_UpdateLastNotified(t *testing.T) {
+	repo, userID, categoryID := newBudgetRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Budget{
+		UserID: userID, CategoryID: categoryID, LimitCents: 1000,
+		Period: domain.BudgetPeriodMonthly, CurrencyCode: "USD", NotifyAtPercent: 50,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, repo.UpdateLastNotified(ctx, created.ID, 75))
+
+	fetched, err := repo.GetByID(ctx, created.ID, userID)
+	require.NoError(t, err)
+	assert.Equal(t, 75, fetched.LastNotifiedPercent)
+}
+
+func TestBudgetRepository_ListDistinctUserIDs(t *testing.T) {
+	repo, user1, cat1 := newBudgetRepoFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	user2 := testutil.SeedUser(t, pool, time.Now().UnixNano()+2)
+	cat2 := testutil.SeedCategory(t, pool, user2, "X", "expense")
+
+	ctx := context.Background()
+	_, _ = repo.Create(ctx, &domain.Budget{UserID: user1, CategoryID: cat1, LimitCents: 1, Period: domain.BudgetPeriodMonthly, CurrencyCode: "USD"})
+	_, _ = repo.Create(ctx, &domain.Budget{UserID: user1, CategoryID: cat1, LimitCents: 2, Period: domain.BudgetPeriodWeekly, CurrencyCode: "USD"})
+	_, _ = repo.Create(ctx, &domain.Budget{UserID: user2, CategoryID: cat2, LimitCents: 3, Period: domain.BudgetPeriodMonthly, CurrencyCode: "USD"})
+
+	ids, err := repo.ListDistinctUserIDs(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, ids, user1)
+	assert.Contains(t, ids, user2)
+}

--- a/internal/repository/exchange_snapshot_test.go
+++ b/internal/repository/exchange_snapshot_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/repository"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+func newSnapshotRepoFixtures(t *testing.T) *repository.ExchangeSnapshotRepository {
+	t.Helper()
+	pool := testutil.OpenTestPool(t)
+	testutil.CleanupTables(t, pool)
+	t.Cleanup(func() { testutil.CleanupTables(t, pool) })
+	return repository.NewExchangeSnapshotRepository(pool)
+}
+
+func TestExchangeSnapshotRepository_UpsertAndGetRate(t *testing.T) {
+	repo := newSnapshotRepoFixtures(t)
+	ctx := context.Background()
+	date := time.Now().UTC().Truncate(24 * time.Hour)
+
+	require.NoError(t, repo.Upsert(ctx, date, "USD", "EUR", 0.92))
+
+	rate, err := repo.GetRate(ctx, date, "USD", "EUR")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.92, rate, 0.0001)
+}
+
+func TestExchangeSnapshotRepository_Upsert_OverridesExistingRate(t *testing.T) {
+	repo := newSnapshotRepoFixtures(t)
+	ctx := context.Background()
+	date := time.Now().UTC().Truncate(24 * time.Hour)
+
+	require.NoError(t, repo.Upsert(ctx, date, "USD", "EUR", 0.9))
+	require.NoError(t, repo.Upsert(ctx, date, "USD", "EUR", 0.95))
+
+	rate, err := repo.GetRate(ctx, date, "USD", "EUR")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.95, rate, 0.0001)
+}
+
+func TestExchangeSnapshotRepository_GetRateOrLatest_FallsBackToPriorDate(t *testing.T) {
+	repo := newSnapshotRepoFixtures(t)
+	ctx := context.Background()
+	yesterday := time.Now().UTC().Add(-24 * time.Hour).Truncate(24 * time.Hour)
+	today := yesterday.Add(24 * time.Hour)
+
+	require.NoError(t, repo.Upsert(ctx, yesterday, "USD", "EUR", 0.92))
+
+	// today not yet seeded; GetRateOrLatest should fall back to yesterday's rate.
+	rate, err := repo.GetRateOrLatest(ctx, today, "USD", "EUR")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.92, rate, 0.0001)
+}
+
+func TestExchangeSnapshotRepository_ListDistinctBaseCurrencies(t *testing.T) {
+	repo := newSnapshotRepoFixtures(t)
+	ctx := context.Background()
+	date := time.Now().UTC().Truncate(24 * time.Hour)
+
+	require.NoError(t, repo.Upsert(ctx, date, "USD", "EUR", 0.92))
+	require.NoError(t, repo.Upsert(ctx, date, "EUR", "USD", 1.08))
+	require.NoError(t, repo.Upsert(ctx, date, "USD", "GBP", 0.79))
+
+	bases, err := repo.ListDistinctBaseCurrencies(ctx)
+	require.NoError(t, err)
+	assert.Contains(t, bases, "USD")
+	assert.Contains(t, bases, "EUR")
+}
+
+func TestExchangeSnapshotRepository_GetLatestSnapshotDate(t *testing.T) {
+	repo := newSnapshotRepoFixtures(t)
+	ctx := context.Background()
+	d1 := time.Now().UTC().Add(-48 * time.Hour).Truncate(24 * time.Hour)
+	d2 := time.Now().UTC().Truncate(24 * time.Hour)
+
+	require.NoError(t, repo.Upsert(ctx, d1, "USD", "EUR", 0.9))
+	require.NoError(t, repo.Upsert(ctx, d2, "USD", "EUR", 0.95))
+
+	latest, err := repo.GetLatestSnapshotDate(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, d2.Year(), latest.Year())
+	assert.Equal(t, d2.YearDay(), latest.YearDay())
+}

--- a/internal/repository/pgconv_test.go
+++ b/internal/repository/pgconv_test.go
@@ -1,0 +1,123 @@
+package repository
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPgTimestamptz_RoundTrip(t *testing.T) {
+	now := time.Date(2026, 4, 28, 10, 0, 0, 0, time.UTC)
+	got := pgTimestamptz(now)
+	require.True(t, got.Valid)
+	assert.Equal(t, now, got.Time)
+	assert.Equal(t, now, goTime(got))
+}
+
+func TestGoTime_InvalidReturnsZero(t *testing.T) {
+	zero := goTime(pgtype.Timestamptz{})
+	assert.True(t, zero.IsZero())
+}
+
+func TestGoTimePtr_NilWhenInvalid(t *testing.T) {
+	assert.Nil(t, goTimePtr(pgtype.Timestamptz{}))
+
+	now := time.Now().UTC()
+	ptr := goTimePtr(pgtype.Timestamptz{Time: now, Valid: true})
+	require.NotNil(t, ptr)
+	assert.Equal(t, now, *ptr)
+}
+
+func TestPgDate_NilReturnsInvalid(t *testing.T) {
+	d := pgDate(nil)
+	assert.False(t, d.Valid)
+}
+
+func TestPgDate_RoundTrip(t *testing.T) {
+	now := time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC)
+	d := pgDate(&now)
+	require.True(t, d.Valid)
+	assert.Equal(t, now, goDateValue(d))
+}
+
+func TestGoDateValue_InvalidReturnsZero(t *testing.T) {
+	assert.True(t, goDateValue(pgtype.Date{}).IsZero())
+}
+
+func TestGoDatePtr_NilWhenInvalid(t *testing.T) {
+	assert.Nil(t, goDatePtr(pgtype.Date{}))
+	now := time.Now().UTC()
+	ptr := goDatePtr(pgtype.Date{Time: now, Valid: true})
+	require.NotNil(t, ptr)
+	assert.Equal(t, now, *ptr)
+}
+
+func TestPgInt8_AlwaysValid(t *testing.T) {
+	v := pgInt8(42)
+	assert.True(t, v.Valid)
+	assert.Equal(t, int64(42), v.Int64)
+}
+
+func TestPgOptionalInt8_NilReturnsInvalid(t *testing.T) {
+	v := pgOptionalInt8(nil)
+	assert.False(t, v.Valid)
+
+	x := int64(99)
+	v = pgOptionalInt8(&x)
+	assert.True(t, v.Valid)
+	assert.Equal(t, int64(99), v.Int64)
+}
+
+func TestPgOptionalTimestamptz_NilReturnsInvalid(t *testing.T) {
+	v := pgOptionalTimestamptz(nil)
+	assert.False(t, v.Valid)
+
+	now := time.Now().UTC()
+	v = pgOptionalTimestamptz(&now)
+	assert.True(t, v.Valid)
+	assert.Equal(t, now, v.Time)
+}
+
+func TestGoInt64_InvalidReturnsZero(t *testing.T) {
+	assert.Zero(t, goInt64(pgtype.Int8{}))
+}
+
+func TestGoInt64_ValidReturnsValue(t *testing.T) {
+	assert.Equal(t, int64(7), goInt64(pgtype.Int8{Int64: 7, Valid: true}))
+}
+
+func TestGoInt64Ptr(t *testing.T) {
+	assert.Nil(t, goInt64Ptr(pgtype.Int8{}))
+	ptr := goInt64Ptr(pgtype.Int8{Int64: 5, Valid: true})
+	require.NotNil(t, ptr)
+	assert.Equal(t, int64(5), *ptr)
+}
+
+func TestPgNumeric_RoundTrip(t *testing.T) {
+	n := pgNumeric(1.2345)
+	got := goFloat64(n)
+	assert.InDelta(t, 1.2345, got, 0.0001)
+}
+
+func TestGoFloat64_InvalidReturnsOne(t *testing.T) {
+	assert.Equal(t, 1.0, goFloat64(pgtype.Numeric{}))
+}
+
+func TestIsDuplicateError_PgErr23505(t *testing.T) {
+	pgErr := &pgconn.PgError{Code: "23505", Message: "duplicate key"}
+	assert.True(t, isDuplicateError(pgErr))
+}
+
+func TestIsDuplicateError_OtherCode(t *testing.T) {
+	pgErr := &pgconn.PgError{Code: "23502", Message: "not null"}
+	assert.False(t, isDuplicateError(pgErr))
+}
+
+func TestIsDuplicateError_NonPgErr(t *testing.T) {
+	assert.False(t, isDuplicateError(errors.New("plain error")))
+}

--- a/internal/repository/recurring_test.go
+++ b/internal/repository/recurring_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/repository"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+func newRecurringRepoFixtures(t *testing.T) (*repository.RecurringRepository, int64, int64, int64) {
+	t.Helper()
+	pool := testutil.OpenTestPool(t)
+	testutil.CleanupTables(t, pool)
+	t.Cleanup(func() { testutil.CleanupTables(t, pool) })
+
+	userID := testutil.SeedUser(t, pool, time.Now().UnixNano())
+	accountID := testutil.SeedAccount(t, pool, userID, "USD")
+	categoryID := testutil.SeedCategory(t, pool, userID, "Subscriptions", "expense")
+	return repository.NewRecurringRepository(pool), userID, accountID, categoryID
+}
+
+func TestRecurringRepository_Create_PersistsAttributes(t *testing.T) {
+	repo, userID, accountID, categoryID := newRecurringRepoFixtures(t)
+	ctx := context.Background()
+	nextRun := time.Now().UTC().Add(24 * time.Hour).Truncate(time.Second)
+
+	created, err := repo.Create(ctx, &domain.RecurringTransaction{
+		UserID:       userID,
+		AccountID:    accountID,
+		CategoryID:   categoryID,
+		Type:         domain.TransactionTypeExpense,
+		AmountCents:  9999,
+		CurrencyCode: "USD",
+		Note:         "Netflix",
+		Frequency:    domain.FrequencyMonthly,
+		NextRunAt:    nextRun,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+	assert.Equal(t, int64(9999), created.AmountCents)
+	assert.Equal(t, domain.FrequencyMonthly, created.Frequency)
+	assert.True(t, created.IsActive)
+}
+
+func TestRecurringRepository_GetByID_NotFound(t *testing.T) {
+	repo, userID, _, _ := newRecurringRepoFixtures(t)
+	_, err := repo.GetByID(context.Background(), 99_999, userID)
+	assert.ErrorIs(t, err, domain.ErrRecurringNotFound)
+}
+
+func TestRecurringRepository_ToggleActive(t *testing.T) {
+	repo, userID, accountID, categoryID := newRecurringRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.RecurringTransaction{
+		UserID: userID, AccountID: accountID, CategoryID: categoryID,
+		Type: domain.TransactionTypeExpense, AmountCents: 1, CurrencyCode: "USD",
+		Frequency: domain.FrequencyMonthly, NextRunAt: time.Now().UTC().Add(time.Hour),
+	})
+	require.NoError(t, err)
+	assert.True(t, created.IsActive)
+
+	toggled, err := repo.ToggleActive(ctx, created.ID, userID)
+	require.NoError(t, err)
+	assert.False(t, toggled.IsActive)
+
+	toggledBack, err := repo.ToggleActive(ctx, created.ID, userID)
+	require.NoError(t, err)
+	assert.True(t, toggledBack.IsActive)
+}
+
+func TestRecurringRepository_GetDue_ReturnsOnlyOverdueAndActive(t *testing.T) {
+	repo, userID, accountID, categoryID := newRecurringRepoFixtures(t)
+	ctx := context.Background()
+
+	past := time.Now().UTC().Add(-time.Hour)
+	future := time.Now().UTC().Add(24 * time.Hour)
+
+	overdue, err := repo.Create(ctx, &domain.RecurringTransaction{
+		UserID: userID, AccountID: accountID, CategoryID: categoryID,
+		Type: domain.TransactionTypeExpense, AmountCents: 1, CurrencyCode: "USD",
+		Frequency: domain.FrequencyDaily, NextRunAt: past, Note: "due",
+	})
+	require.NoError(t, err)
+
+	_, err = repo.Create(ctx, &domain.RecurringTransaction{
+		UserID: userID, AccountID: accountID, CategoryID: categoryID,
+		Type: domain.TransactionTypeExpense, AmountCents: 2, CurrencyCode: "USD",
+		Frequency: domain.FrequencyDaily, NextRunAt: future, Note: "later",
+	})
+	require.NoError(t, err)
+
+	due, err := repo.GetDue(ctx, time.Now().UTC())
+	require.NoError(t, err)
+	require.Len(t, due, 1)
+	assert.Equal(t, overdue.ID, due[0].ID)
+}
+
+func TestRecurringRepository_UpdateNextRun(t *testing.T) {
+	repo, userID, accountID, categoryID := newRecurringRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.RecurringTransaction{
+		UserID: userID, AccountID: accountID, CategoryID: categoryID,
+		Type: domain.TransactionTypeExpense, AmountCents: 1, CurrencyCode: "USD",
+		Frequency: domain.FrequencyMonthly, NextRunAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	newRun := time.Now().UTC().Add(7 * 24 * time.Hour).Truncate(time.Second)
+	require.NoError(t, repo.UpdateNextRun(ctx, created.ID, newRun))
+
+	fetched, err := repo.GetByID(ctx, created.ID, userID)
+	require.NoError(t, err)
+	assert.WithinDuration(t, newRun, fetched.NextRunAt, time.Second)
+}
+
+func TestRecurringRepository_Delete(t *testing.T) {
+	repo, userID, accountID, categoryID := newRecurringRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.RecurringTransaction{
+		UserID: userID, AccountID: accountID, CategoryID: categoryID,
+		Type: domain.TransactionTypeExpense, AmountCents: 1, CurrencyCode: "USD",
+		Frequency: domain.FrequencyMonthly, NextRunAt: time.Now().UTC(),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Delete(ctx, created.ID, userID))
+	_, err = repo.GetByID(ctx, created.ID, userID)
+	assert.ErrorIs(t, err, domain.ErrRecurringNotFound)
+}

--- a/internal/repository/savings_goal_test.go
+++ b/internal/repository/savings_goal_test.go
@@ -1,0 +1,146 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/repository"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+func newSavingsRepoFixtures(t *testing.T) (*repository.SavingsGoalRepository, int64) {
+	t.Helper()
+	pool := testutil.OpenTestPool(t)
+	testutil.CleanupTables(t, pool)
+	t.Cleanup(func() { testutil.CleanupTables(t, pool) })
+
+	userID := testutil.SeedUser(t, pool, time.Now().UnixNano())
+	return repository.NewSavingsGoalRepository(pool), userID
+}
+
+func TestSavingsGoalRepository_Create_PersistsAttributes(t *testing.T) {
+	repo, userID := newSavingsRepoFixtures(t)
+	ctx := context.Background()
+	deadline := time.Now().UTC().Add(30 * 24 * time.Hour).Truncate(time.Second)
+
+	created, err := repo.Create(ctx, &domain.SavingsGoal{
+		UserID:       userID,
+		Name:         "Vacation",
+		TargetCents:  500_000,
+		CurrencyCode: "USD",
+		Deadline:     &deadline,
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+	assert.Equal(t, "Vacation", created.Name)
+	assert.Equal(t, int64(500_000), created.TargetCents)
+	assert.Equal(t, int64(0), created.CurrentCents)
+	require.NotNil(t, created.Deadline)
+}
+
+func TestSavingsGoalRepository_GetByID_NotFound(t *testing.T) {
+	repo, userID := newSavingsRepoFixtures(t)
+	_, err := repo.GetByID(context.Background(), 99_999, userID)
+	assert.ErrorIs(t, err, domain.ErrGoalNotFound)
+}
+
+func TestSavingsGoalRepository_Deposit_IncreasesCurrent(t *testing.T) {
+	repo, userID := newSavingsRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.SavingsGoal{
+		UserID: userID, Name: "Car", TargetCents: 1_000_000, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	updated, err := repo.Deposit(ctx, created.ID, userID, 25_000)
+	require.NoError(t, err)
+	assert.Equal(t, int64(25_000), updated.CurrentCents)
+
+	updated, err = repo.Deposit(ctx, created.ID, userID, 75_000)
+	require.NoError(t, err)
+	assert.Equal(t, int64(100_000), updated.CurrentCents)
+}
+
+func TestSavingsGoalRepository_Withdraw_DecreasesCurrent(t *testing.T) {
+	repo, userID := newSavingsRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.SavingsGoal{
+		UserID: userID, Name: "Phone", TargetCents: 100_000, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	_, err = repo.Deposit(ctx, created.ID, userID, 50_000)
+	require.NoError(t, err)
+
+	updated, err := repo.Withdraw(ctx, created.ID, userID, 20_000)
+	require.NoError(t, err)
+	assert.Equal(t, int64(30_000), updated.CurrentCents)
+}
+
+func TestSavingsGoalRepository_Withdraw_RejectsInsufficient(t *testing.T) {
+	repo, userID := newSavingsRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.SavingsGoal{
+		UserID: userID, Name: "Phone", TargetCents: 100_000, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	_, err = repo.Withdraw(ctx, created.ID, userID, 1)
+	assert.ErrorIs(t, err, domain.ErrInsufficientGoalFunds)
+}
+
+func TestSavingsGoalRepository_ListHistory(t *testing.T) {
+	repo, userID := newSavingsRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.SavingsGoal{
+		UserID: userID, Name: "Vacation", TargetCents: 100_000, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	_, err = repo.Deposit(ctx, created.ID, userID, 1000)
+	require.NoError(t, err)
+	_, err = repo.Deposit(ctx, created.ID, userID, 500)
+	require.NoError(t, err)
+	_, err = repo.Withdraw(ctx, created.ID, userID, 200)
+	require.NoError(t, err)
+
+	history, err := repo.ListHistory(ctx, created.ID, userID)
+	require.NoError(t, err)
+	require.Len(t, history, 3)
+}
+
+func TestSavingsGoalRepository_Update_AndDelete(t *testing.T) {
+	repo, userID := newSavingsRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.SavingsGoal{
+		UserID: userID, Name: "Old", TargetCents: 100, CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+
+	updated, err := repo.Update(ctx, &domain.SavingsGoal{
+		ID:           created.ID,
+		UserID:       userID,
+		Name:         "New",
+		TargetCents:  200,
+		CurrencyCode: "USD",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "New", updated.Name)
+	assert.Equal(t, int64(200), updated.TargetCents)
+
+	require.NoError(t, repo.Delete(ctx, created.ID, userID))
+	_, err = repo.GetByID(ctx, created.ID, userID)
+	assert.ErrorIs(t, err, domain.ErrGoalNotFound)
+}

--- a/internal/repository/transfer_test.go
+++ b/internal/repository/transfer_test.go
@@ -1,0 +1,132 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/repository"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+func newTransferRepoFixtures(t *testing.T) (*repository.TransferRepository, int64, int64, int64) {
+	t.Helper()
+	pool := testutil.OpenTestPool(t)
+	testutil.CleanupTables(t, pool)
+	t.Cleanup(func() { testutil.CleanupTables(t, pool) })
+
+	userID := testutil.SeedUser(t, pool, time.Now().UnixNano())
+	from := testutil.SeedAccount(t, pool, userID, "USD")
+	to := testutil.SeedAccount(t, pool, userID, "EUR")
+	return repository.NewTransferRepository(pool), userID, from, to
+}
+
+func TestTransferRepository_Create_PersistsAttributes(t *testing.T) {
+	repo, userID, from, to := newTransferRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Transfer{
+		UserID:           userID,
+		FromAccountID:    from,
+		ToAccountID:      to,
+		AmountCents:      10_000,
+		FromCurrencyCode: "USD",
+		ToCurrencyCode:   "EUR",
+		ExchangeRate:     0.92,
+		Note:             "March transfer",
+	})
+	require.NoError(t, err)
+	require.NotZero(t, created.ID)
+	assert.Equal(t, int64(10_000), created.AmountCents)
+	assert.Equal(t, "USD", created.FromCurrencyCode)
+	assert.Equal(t, "EUR", created.ToCurrencyCode)
+	assert.InDelta(t, 0.92, created.ExchangeRate, 0.0001)
+}
+
+func TestTransferRepository_GetByID_NotFound(t *testing.T) {
+	repo, userID, _, _ := newTransferRepoFixtures(t)
+	_, err := repo.GetByID(context.Background(), 99_999, userID)
+	assert.ErrorIs(t, err, domain.ErrTransactionNotFound)
+}
+
+func TestTransferRepository_ListByUser_Pagination(t *testing.T) {
+	repo, userID, from, to := newTransferRepoFixtures(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		_, err := repo.Create(ctx, &domain.Transfer{
+			UserID: userID, FromAccountID: from, ToAccountID: to,
+			AmountCents: int64(100 * (i + 1)), FromCurrencyCode: "USD", ToCurrencyCode: "EUR",
+			ExchangeRate: 0.9,
+		})
+		require.NoError(t, err)
+	}
+
+	page1, err := repo.ListByUser(ctx, userID, 2, 0)
+	require.NoError(t, err)
+	assert.Len(t, page1, 2)
+
+	page2, err := repo.ListByUser(ctx, userID, 2, 2)
+	require.NoError(t, err)
+	assert.Len(t, page2, 1)
+}
+
+func TestTransferRepository_Count(t *testing.T) {
+	repo, userID, from, to := newTransferRepoFixtures(t)
+	ctx := context.Background()
+
+	for i := 0; i < 4; i++ {
+		_, err := repo.Create(ctx, &domain.Transfer{
+			UserID: userID, FromAccountID: from, ToAccountID: to,
+			AmountCents: 100, FromCurrencyCode: "USD", ToCurrencyCode: "EUR", ExchangeRate: 1,
+		})
+		require.NoError(t, err)
+	}
+
+	n, err := repo.Count(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), n)
+}
+
+func TestTransferRepository_ListByAccount(t *testing.T) {
+	repo, userID, from, to := newTransferRepoFixtures(t)
+	pool := testutil.OpenTestPool(t)
+	other := testutil.SeedAccount(t, pool, userID, "USD")
+	ctx := context.Background()
+
+	_, err := repo.Create(ctx, &domain.Transfer{
+		UserID: userID, FromAccountID: from, ToAccountID: to,
+		AmountCents: 100, FromCurrencyCode: "USD", ToCurrencyCode: "EUR", ExchangeRate: 0.9,
+	})
+	require.NoError(t, err)
+	_, err = repo.Create(ctx, &domain.Transfer{
+		UserID: userID, FromAccountID: from, ToAccountID: other,
+		AmountCents: 200, FromCurrencyCode: "USD", ToCurrencyCode: "USD", ExchangeRate: 1,
+	})
+	require.NoError(t, err)
+
+	list, err := repo.ListByAccount(ctx, userID, from)
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+}
+
+func TestTransferRepository_Delete(t *testing.T) {
+	repo, userID, from, to := newTransferRepoFixtures(t)
+	ctx := context.Background()
+
+	created, err := repo.Create(ctx, &domain.Transfer{
+		UserID: userID, FromAccountID: from, ToAccountID: to,
+		AmountCents: 100, FromCurrencyCode: "USD", ToCurrencyCode: "EUR", ExchangeRate: 0.9,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, repo.Delete(ctx, created.ID, userID))
+	_, err = repo.GetByID(ctx, created.ID, userID)
+	assert.ErrorIs(t, err, domain.ErrTransactionNotFound)
+}

--- a/internal/repository/user_test.go
+++ b/internal/repository/user_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/repository"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+func newUserRepoFixtures(t *testing.T) (*repository.UserRepository, *testutilPool) {
+	t.Helper()
+	pool := testutil.OpenTestPool(t)
+	testutil.CleanupTables(t, pool)
+	t.Cleanup(func() { testutil.CleanupTables(t, pool) })
+	return repository.NewUserRepository(pool), &testutilPool{pool: pool, idCounter: time.Now().UnixNano()}
+}
+
+// testutilPool tracks the next user ID to keep tests deterministic across calls
+// to time.Now().UnixNano(), which can collide on fast Windows clocks.
+type testutilPool struct {
+	pool      interface{}
+	idCounter int64
+}
+
+func (p *testutilPool) nextID() int64 {
+	p.idCounter++
+	return p.idCounter
+}
+
+func TestUserRepository_Upsert_CreatesNewUser(t *testing.T) {
+	repo, ids := newUserRepoFixtures(t)
+	ctx := context.Background()
+
+	user, err := repo.Upsert(ctx, &domain.User{
+		ID:        ids.nextID(),
+		Username:  "alice",
+		FirstName: "Alice",
+		LastName:  "A.",
+		Language:  domain.LangEN,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "alice", user.Username)
+	assert.Equal(t, "Alice", user.FirstName)
+	assert.Equal(t, domain.LangEN, user.Language)
+}
+
+func TestUserRepository_Upsert_UpdatesExisting(t *testing.T) {
+	repo, ids := newUserRepoFixtures(t)
+	ctx := context.Background()
+
+	id := ids.nextID()
+	_, err := repo.Upsert(ctx, &domain.User{ID: id, Username: "old", FirstName: "Old", Language: domain.LangEN})
+	require.NoError(t, err)
+
+	updated, err := repo.Upsert(ctx, &domain.User{ID: id, Username: "renamed", FirstName: "New", Language: domain.LangEN})
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", updated.Username)
+	assert.Equal(t, "New", updated.FirstName)
+}
+
+func TestUserRepository_GetByID_NotFound(t *testing.T) {
+	repo, _ := newUserRepoFixtures(t)
+	_, err := repo.GetByID(context.Background(), 99_999_999)
+	assert.ErrorIs(t, err, domain.ErrUserNotFound)
+}
+
+func TestUserRepository_UpdateLanguage(t *testing.T) {
+	repo, ids := newUserRepoFixtures(t)
+	ctx := context.Background()
+
+	id := ids.nextID()
+	_, err := repo.Upsert(ctx, &domain.User{ID: id, Username: "u", FirstName: "U", Language: domain.LangEN})
+	require.NoError(t, err)
+
+	updated, err := repo.UpdateLanguage(ctx, id, "ru")
+	require.NoError(t, err)
+	assert.Equal(t, domain.Language("ru"), updated.Language)
+}
+
+func TestUserRepository_UpdateNotificationPreferences(t *testing.T) {
+	repo, ids := newUserRepoFixtures(t)
+	ctx := context.Background()
+
+	id := ids.nextID()
+	_, err := repo.Upsert(ctx, &domain.User{ID: id, Username: "u", FirstName: "U", Language: domain.LangEN})
+	require.NoError(t, err)
+
+	prefs := domain.NotificationPrefs{
+		BudgetAlerts:       false,
+		RecurringReminders: true,
+		WeeklySummary:      false,
+		GoalMilestones:     true,
+	}
+	updated, err := repo.UpdateNotificationPreferences(ctx, id, prefs)
+	require.NoError(t, err)
+	assert.False(t, updated.NotifyBudgetAlerts)
+	assert.True(t, updated.NotifyRecurringReminders)
+	assert.False(t, updated.NotifyWeeklySummary)
+	assert.True(t, updated.NotifyGoalMilestones)
+}
+
+func TestUserRepository_UpdateDisplayCurrencies(t *testing.T) {
+	repo, ids := newUserRepoFixtures(t)
+	ctx := context.Background()
+
+	id := ids.nextID()
+	_, err := repo.Upsert(ctx, &domain.User{ID: id, Username: "u", FirstName: "U", Language: domain.LangEN})
+	require.NoError(t, err)
+
+	updated, err := repo.UpdateDisplayCurrencies(ctx, id, "USD,EUR,RUB")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"USD", "EUR", "RUB"}, updated.DisplayCurrencies)
+}

--- a/internal/scheduler/export_test.go
+++ b/internal/scheduler/export_test.go
@@ -1,0 +1,19 @@
+package scheduler
+
+// Tick exposes tick for use in tests without changing the production API.
+func (s *Scheduler) Tick() {
+	s.tick(nil)
+}
+
+// SaveSnapshots exposes saveSnapshots for tests.
+func (s *Scheduler) SaveSnapshots() {
+	s.saveSnapshots(nil)
+}
+
+// CheckBudgets exposes checkBudgets for tests.
+func (s *Scheduler) CheckBudgets() {
+	s.checkBudgets(nil)
+}
+
+// LastSnapshot returns the cached last successful snapshot date.
+func (s *Scheduler) LastSnapshot() any { return s.lastSnapshot }

--- a/internal/scheduler/export_test.go
+++ b/internal/scheduler/export_test.go
@@ -1,18 +1,20 @@
 package scheduler
 
+import "context"
+
 // Tick exposes tick for use in tests without changing the production API.
 func (s *Scheduler) Tick() {
-	s.tick(nil)
+	s.tick(context.Background())
 }
 
 // SaveSnapshots exposes saveSnapshots for tests.
 func (s *Scheduler) SaveSnapshots() {
-	s.saveSnapshots(nil)
+	s.saveSnapshots(context.Background())
 }
 
 // CheckBudgets exposes checkBudgets for tests.
 func (s *Scheduler) CheckBudgets() {
-	s.checkBudgets(nil)
+	s.checkBudgets(context.Background())
 }
 
 // LastSnapshot returns the cached last successful snapshot date.

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,140 @@
+package scheduler_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/scheduler"
+	"github.com/horexdev/money-tracker/internal/testutil"
+)
+
+type fakeRecurring struct{ mock.Mock }
+
+func (f *fakeRecurring) ProcessDue(ctx context.Context) (int, error) {
+	args := f.Called(ctx)
+	return args.Int(0), args.Error(1)
+}
+
+type fakeBudgets struct{ mock.Mock }
+
+func (f *fakeBudgets) ListDistinctUserIDs(ctx context.Context) ([]int64, error) {
+	args := f.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]int64), args.Error(1)
+}
+
+func (f *fakeBudgets) CheckAndNotify(ctx context.Context, userID int64) error {
+	args := f.Called(ctx, userID)
+	return args.Error(0)
+}
+
+type fakeSnapshots struct{ mock.Mock }
+
+func (f *fakeSnapshots) SaveDaily(ctx context.Context) error {
+	args := f.Called(ctx)
+	return args.Error(0)
+}
+
+func TestScheduler_Tick_RunsAllJobs(t *testing.T) {
+	rec := &fakeRecurring{}
+	bud := &fakeBudgets{}
+	snap := &fakeSnapshots{}
+
+	rec.On("ProcessDue", mock.Anything).Return(2, nil)
+	bud.On("ListDistinctUserIDs", mock.Anything).Return([]int64{10, 20}, nil)
+	bud.On("CheckAndNotify", mock.Anything, int64(10)).Return(nil)
+	bud.On("CheckAndNotify", mock.Anything, int64(20)).Return(nil)
+	snap.On("SaveDaily", mock.Anything).Return(nil)
+
+	s := scheduler.New(rec, bud, snap, testutil.TestLogger(), time.Hour)
+	s.Tick()
+
+	rec.AssertExpectations(t)
+	bud.AssertExpectations(t)
+	snap.AssertCalled(t, "SaveDaily", mock.Anything)
+}
+
+func TestScheduler_Tick_ContinuesOnRecurringError(t *testing.T) {
+	rec := &fakeRecurring{}
+	snap := &fakeSnapshots{}
+	rec.On("ProcessDue", mock.Anything).Return(0, errors.New("db down"))
+	snap.On("SaveDaily", mock.Anything).Return(nil)
+
+	s := scheduler.New(rec, nil, snap, testutil.TestLogger(), time.Hour)
+	s.Tick() // must not panic, must still call snapshots
+	snap.AssertCalled(t, "SaveDaily", mock.Anything)
+}
+
+func TestScheduler_Tick_NilBudgetsSkipped(t *testing.T) {
+	rec := &fakeRecurring{}
+	snap := &fakeSnapshots{}
+	rec.On("ProcessDue", mock.Anything).Return(0, nil)
+	snap.On("SaveDaily", mock.Anything).Return(nil)
+
+	s := scheduler.New(rec, nil, snap, testutil.TestLogger(), time.Hour)
+	s.Tick()
+	rec.AssertExpectations(t)
+}
+
+func TestScheduler_SaveSnapshots_Idempotent(t *testing.T) {
+	snap := &fakeSnapshots{}
+	snap.On("SaveDaily", mock.Anything).Return(nil).Once()
+
+	s := scheduler.New(&fakeRecurring{}, nil, snap, testutil.TestLogger(), time.Hour)
+	s.SaveSnapshots() // first call: invokes SaveDaily
+	s.SaveSnapshots() // second call same day: must not invoke again
+	snap.AssertNumberOfCalls(t, "SaveDaily", 1)
+}
+
+func TestScheduler_CheckBudgets_ListErrorIsLoggedAndIgnored(t *testing.T) {
+	bud := &fakeBudgets{}
+	bud.On("ListDistinctUserIDs", mock.Anything).Return(nil, errors.New("db"))
+
+	s := scheduler.New(&fakeRecurring{}, bud, nil, testutil.TestLogger(), time.Hour)
+	s.CheckBudgets()
+	bud.AssertNotCalled(t, "CheckAndNotify", mock.Anything, mock.Anything)
+}
+
+func TestScheduler_CheckBudgets_PerUserErrorContinues(t *testing.T) {
+	bud := &fakeBudgets{}
+	bud.On("ListDistinctUserIDs", mock.Anything).Return([]int64{1, 2, 3}, nil)
+	bud.On("CheckAndNotify", mock.Anything, int64(1)).Return(nil)
+	bud.On("CheckAndNotify", mock.Anything, int64(2)).Return(errors.New("user 2 failed"))
+	bud.On("CheckAndNotify", mock.Anything, int64(3)).Return(nil)
+
+	s := scheduler.New(&fakeRecurring{}, bud, nil, testutil.TestLogger(), time.Hour)
+	s.CheckBudgets()
+	bud.AssertNumberOfCalls(t, "CheckAndNotify", 3)
+}
+
+func TestScheduler_Run_StopsOnContextCancel(t *testing.T) {
+	rec := &fakeRecurring{}
+	rec.On("ProcessDue", mock.Anything).Return(0, nil)
+	snap := &fakeSnapshots{}
+	snap.On("SaveDaily", mock.Anything).Return(nil)
+
+	s := scheduler.New(rec, nil, snap, testutil.TestLogger(), 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.Run(ctx)
+		close(done)
+	}()
+	time.Sleep(120 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+		// ok — Run returned promptly after cancel
+	case <-time.After(time.Second):
+		require.Fail(t, "Run did not return within 1s of cancel")
+	}
+	assert.GreaterOrEqual(t, len(rec.Calls), 1, "Run should have ticked at least once")
+}

--- a/internal/service/snapshot_test.go
+++ b/internal/service/snapshot_test.go
@@ -1,0 +1,118 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/horexdev/money-tracker/internal/domain"
+	"github.com/horexdev/money-tracker/internal/service"
+	"github.com/horexdev/money-tracker/internal/testutil"
+	"github.com/horexdev/money-tracker/internal/testutil/mocks"
+)
+
+func newSnapshotService(repo *mocks.MockSnapshotStorer, provider *mocks.MockRateProvider) *service.SnapshotService {
+	return service.NewSnapshotService(repo, provider, testutil.TestLogger())
+}
+
+func TestSnapshotService_GetRate_SameCurrencyReturnsOne(t *testing.T) {
+	repo := &mocks.MockSnapshotStorer{}
+	svc := newSnapshotService(repo, &mocks.MockRateProvider{})
+
+	rate, err := svc.GetRate(context.Background(), time.Now(), "USD", "USD")
+	require.NoError(t, err)
+	assert.Equal(t, 1.0, rate)
+}
+
+func TestSnapshotService_GetRate_LooksUpHistoricalRate(t *testing.T) {
+	repo := &mocks.MockSnapshotStorer{}
+	svc := newSnapshotService(repo, &mocks.MockRateProvider{})
+	date := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	repo.On("GetRateOrLatest", mock.Anything, date, "USD", "EUR").Return(0.92, nil)
+
+	rate, err := svc.GetRate(context.Background(), date, "USD", "EUR")
+	require.NoError(t, err)
+	assert.InDelta(t, 0.92, rate, 0.0001)
+}
+
+func TestSnapshotService_GetRate_WrapsRepoErrorAsExchangeUnavailable(t *testing.T) {
+	repo := &mocks.MockSnapshotStorer{}
+	svc := newSnapshotService(repo, &mocks.MockRateProvider{})
+	repo.On("GetRateOrLatest", mock.Anything, mock.Anything, "USD", "EUR").
+		Return(0.0, errors.New("not in db"))
+
+	_, err := svc.GetRate(context.Background(), time.Now(), "USD", "EUR")
+	assert.ErrorIs(t, err, domain.ErrExchangeRateUnavailable)
+}
+
+func TestSnapshotService_Convert_AppliesRateAndRounds(t *testing.T) {
+	repo := &mocks.MockSnapshotStorer{}
+	svc := newSnapshotService(repo, &mocks.MockRateProvider{})
+	repo.On("GetRateOrLatest", mock.Anything, mock.Anything, "USD", "EUR").Return(0.92, nil)
+
+	got, err := svc.Convert(context.Background(), 10000, "USD", "EUR", time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, int64(9200), got)
+}
+
+func TestSnapshotService_SaveDaily_NoBasesNoFetch(t *testing.T) {
+	repo := &mocks.MockSnapshotStorer{}
+	provider := &mocks.MockRateProvider{}
+	svc := newSnapshotService(repo, provider)
+
+	repo.On("ListDistinctBaseCurrencies", mock.Anything).Return([]string{}, nil)
+
+	err := svc.SaveDaily(context.Background())
+	require.NoError(t, err)
+	provider.AssertNotCalled(t, "FetchRates", mock.Anything, mock.Anything)
+	repo.AssertNotCalled(t, "Upsert", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestSnapshotService_SaveDaily_FetchesAndUpserts(t *testing.T) {
+	repo := &mocks.MockSnapshotStorer{}
+	provider := &mocks.MockRateProvider{}
+	svc := newSnapshotService(repo, provider)
+
+	repo.On("ListDistinctBaseCurrencies", mock.Anything).Return([]string{"USD"}, nil)
+	provider.On("FetchRates", mock.Anything, "USD").Return(map[string]float64{
+		"USD": 1.0,
+		"EUR": 0.92,
+		"GBP": 0.79,
+	}, nil)
+	// Upsert called for non-base entries (EUR, GBP)
+	repo.On("Upsert", mock.Anything, mock.AnythingOfType("time.Time"), "USD", "EUR", 0.92).Return(nil)
+	repo.On("Upsert", mock.Anything, mock.AnythingOfType("time.Time"), "USD", "GBP", 0.79).Return(nil)
+
+	err := svc.SaveDaily(context.Background())
+	require.NoError(t, err)
+	repo.AssertNumberOfCalls(t, "Upsert", 2)
+}
+
+func TestSnapshotService_SaveDaily_ContinuesOnFetchError(t *testing.T) {
+	repo := &mocks.MockSnapshotStorer{}
+	provider := &mocks.MockRateProvider{}
+	svc := newSnapshotService(repo, provider)
+
+	repo.On("ListDistinctBaseCurrencies", mock.Anything).Return([]string{"USD", "EUR"}, nil)
+	provider.On("FetchRates", mock.Anything, "USD").Return(nil, errors.New("API down"))
+	provider.On("FetchRates", mock.Anything, "EUR").Return(map[string]float64{"USD": 1.08}, nil)
+	repo.On("Upsert", mock.Anything, mock.AnythingOfType("time.Time"), "EUR", "USD", 1.08).Return(nil)
+
+	err := svc.SaveDaily(context.Background())
+	require.NoError(t, err)
+	repo.AssertNumberOfCalls(t, "Upsert", 1)
+}
+
+func TestSnapshotService_SaveDaily_ListBasesError(t *testing.T) {
+	repo := &mocks.MockSnapshotStorer{}
+	svc := newSnapshotService(repo, &mocks.MockRateProvider{})
+	repo.On("ListDistinctBaseCurrencies", mock.Anything).Return(nil, errors.New("db down"))
+
+	err := svc.SaveDaily(context.Background())
+	require.Error(t, err)
+}

--- a/internal/testutil/mocks/snapshot_storer.go
+++ b/internal/testutil/mocks/snapshot_storer.go
@@ -1,0 +1,41 @@
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// MockSnapshotStorer is a testify mock for service.SnapshotStorer.
+type MockSnapshotStorer struct {
+	mock.Mock
+}
+
+func (m *MockSnapshotStorer) Upsert(ctx context.Context, date time.Time, base, target string, rate float64) error {
+	args := m.Called(ctx, date, base, target, rate)
+	return args.Error(0)
+}
+
+func (m *MockSnapshotStorer) GetRate(ctx context.Context, date time.Time, base, target string) (float64, error) {
+	args := m.Called(ctx, date, base, target)
+	return args.Get(0).(float64), args.Error(1)
+}
+
+func (m *MockSnapshotStorer) GetRateOrLatest(ctx context.Context, date time.Time, base, target string) (float64, error) {
+	args := m.Called(ctx, date, base, target)
+	return args.Get(0).(float64), args.Error(1)
+}
+
+func (m *MockSnapshotStorer) ListDistinctBaseCurrencies(ctx context.Context) ([]string, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockSnapshotStorer) GetLatestSnapshotDate(ctx context.Context) (time.Time, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(time.Time), args.Error(1)
+}

--- a/web/src/features/add-transaction/index.tsx
+++ b/web/src/features/add-transaction/index.tsx
@@ -60,10 +60,13 @@ export function AddTransactionPage() {
   useEffect(() => {
     if (accounts.length === 0) return
     const def = accounts.find(a => a.is_default) ?? accounts[0]
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (selectedAccountId === null) setSelectedAccountId(def.id)
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (fromAccountId === null) setFromAccountId(def.id)
     if (toAccountId === null) {
       const second = accounts.find(a => a.id !== def.id)
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       if (second) setToAccountId(second.id)
     }
   }, [accounts]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -77,6 +80,7 @@ export function AddTransactionPage() {
 
   useEffect(() => {
     if (!needsExchangeRate || !fromAccount || !toAccount) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setExchangeRate(null)
       return
     }
@@ -153,7 +157,7 @@ export function AddTransactionPage() {
         account_id: selectedAccountId!,
       })
     }
-  }, [canSubmit, isTransfer, fromAccountId, toAccountId, amount, note, categoryID, mode, txDate, selectedAccountId, txMutation, transferMutation])
+  }, [canSubmit, isTransfer, fromAccountId, toAccountId, amount, note, exchangeRate, categoryID, mode, txDate, selectedAccountId, txMutation, transferMutation])
 
   const handleModeChange = (m: Mode) => {
     setMode(m)

--- a/web/src/features/dashboard/index.tsx
+++ b/web/src/features/dashboard/index.tsx
@@ -34,7 +34,10 @@ function SpringMoney({ cents, currency, className }: MoneyProps) {
   const formatterRef = useRef((v: number) => formatCents(Math.round(v), currency))
   const [display, setDisplay] = useState(() => formatCents(cents, currency))
 
-  formatterRef.current = (v: number) => formatCents(Math.round(v), currency)
+  // Keep the formatter ref in sync without writing during render.
+  useEffect(() => {
+    formatterRef.current = (v: number) => formatCents(Math.round(v), currency)
+  }, [currency])
 
   useEffect(() => {
     spring.set(cents)
@@ -43,7 +46,7 @@ function SpringMoney({ cents, currency, className }: MoneyProps) {
   // When currency changes, snap immediately (avoid showing wrong currency symbol during animation)
   useEffect(() => {
     setDisplay(formatCents(Math.round(spring.get()), currency))
-  }, [currency]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [currency, spring])
 
   useMotionValueEvent(spring, 'change', (v) => {
     setDisplay(formatterRef.current(v))
@@ -64,10 +67,14 @@ export function DashboardPage() {
     queryFn: accountsApi.list,
   })
 
-  // Pre-select the default account once accounts load
+  // Pre-select the default account once accounts load. The setState call
+  // inside an effect is intentional — there is no place to derive
+  // selectedAccountId from at render time without breaking the user's manual
+  // selection later.
   useEffect(() => {
     if (selectedAccountId === null && accounts.length > 0) {
       const def = accounts.find(a => a.is_default) ?? accounts[0]
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedAccountId(def.id)
     }
   }, [accounts, selectedAccountId])

--- a/web/src/features/features-smoke.test.tsx
+++ b/web/src/features/features-smoke.test.tsx
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from '@testing-library/react'
+
+vi.mock('../shared/api/balance', () => ({
+  balanceApi: {
+    get: vi.fn().mockResolvedValue({
+      total_in_base_cents: 100000,
+      by_currency: [{ currency_code: 'USD', income_cents: 200000, expense_cents: 100000, net_cents: 100000 }],
+      display_conversions: [],
+    }),
+  },
+}))
+
+vi.mock('../shared/api/transactions', () => ({
+  transactionsApi: {
+    list: vi.fn().mockResolvedValue({
+      transactions: [],
+      total: 0,
+      page: 1,
+      page_size: 20,
+      total_pages: 0,
+    }),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('../shared/api/accounts', () => ({
+  accountsApi: {
+    list: vi.fn().mockResolvedValue([
+      { id: 1, name: 'Main', is_default: true, currency_code: 'USD', balance_cents: 100000, type: 'cash', icon: 'wallet', color: '#000', include_in_total: true },
+    ]),
+    getById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    setDefault: vi.fn(),
+    delete: vi.fn(),
+    adjust: vi.fn(),
+  },
+}))
+
+vi.mock('../shared/api/settings', () => ({
+  settingsApi: {
+    get: vi.fn().mockResolvedValue({
+      base_currency: 'USD',
+      display_currencies: [],
+      language: 'en',
+      is_admin: false,
+      notify_budget_alerts: true,
+      notify_recurring_reminders: true,
+      notify_weekly_summary: false,
+      notify_goal_milestones: true,
+    }),
+    update: vi.fn(),
+    resetData: vi.fn(),
+  },
+}))
+
+vi.mock('../shared/api/categories', () => ({
+  categoriesApi: {
+    list: vi.fn().mockResolvedValue({ categories: [] }),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('../shared/hooks/useHaptic', () => ({
+  useHaptic: () => ({ impact: vi.fn(), notification: vi.fn(), selection: vi.fn() }),
+}))
+
+vi.mock('../shared/hooks/useMainButton', () => ({
+  useTgMainButton: vi.fn(),
+}))
+
+import { DashboardPage } from './dashboard'
+import { HistoryPage } from './history'
+import { MorePage } from './more'
+import { SettingsPage } from './settings'
+import { renderWithProviders } from '../test/render'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('DashboardPage smoke', () => {
+  it('renders without crashing and shows the formatted balance', async () => {
+    renderWithProviders(<DashboardPage />)
+    await waitFor(() => {
+      // Balance card eventually shows the USD amount.
+      expect(screen.getAllByText(/\$1,000\.00/).length).toBeGreaterThan(0)
+    })
+  })
+})
+
+describe('HistoryPage smoke', () => {
+  it('renders without crashing and shows the empty state when no transactions', async () => {
+    renderWithProviders(<HistoryPage />)
+    // Once queries resolve, empty state is rendered.
+    await waitFor(() => {
+      // EmptyState contains a title from i18n, but missing translations fall back to key — accept either.
+      expect(document.body.textContent).toBeTruthy()
+    })
+  })
+})
+
+describe('MorePage smoke', () => {
+  it('renders the menu grid', () => {
+    renderWithProviders(<MorePage />)
+    // Featured budget card link is always rendered with /budgets href.
+    const links = document.querySelectorAll('a[href="/budgets"]')
+    expect(links.length).toBeGreaterThan(0)
+  })
+
+  it('renders the always-active grid items', () => {
+    renderWithProviders(<MorePage />)
+    // /export is marked comingSoon and may render as a non-link element.
+    for (const path of ['/savings', '/recurring', '/categories', '/accounts', '/settings']) {
+      const link = document.querySelector(`a[href="${path}"]`)
+      expect(link, `expected link to ${path}`).not.toBeNull()
+    }
+  })
+})
+
+describe('SettingsPage smoke', () => {
+  it('renders without crashing', async () => {
+    renderWithProviders(<SettingsPage />)
+    await waitFor(() => {
+      expect(document.body.textContent?.length).toBeGreaterThan(0)
+    })
+  })
+})

--- a/web/src/features/recurring/index.tsx
+++ b/web/src/features/recurring/index.tsx
@@ -122,6 +122,7 @@ function RecurringForm({
   useEffect(() => {
     if (accounts.length === 0) return
     const def = accounts.find(a => a.is_default) ?? accounts[0]
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     if (accountID === null) setAccountID(def.id)
   }, [accounts]) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/web/src/features/stats/index.tsx
+++ b/web/src/features/stats/index.tsx
@@ -40,17 +40,21 @@ function StaticNumber({ value, formatter }: NumberProps) {
 function SpringNumber({ value, formatter }: NumberProps) {
   const spring = useSpring(0, { stiffness: 80, damping: 20 })
   const formatterRef = useRef(formatter)
-  formatterRef.current = formatter
 
   const [display, setDisplay] = useState(() =>
     formatter ? formatter(value) : value.toString()
   )
 
   useEffect(() => {
+    formatterRef.current = formatter
+  }, [formatter])
+
+  useEffect(() => {
     spring.set(value)
     // Re-render display immediately when formatter changes (e.g. currency switch)
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setDisplay(formatterRef.current ? formatterRef.current(Math.round(spring.get())) : Math.round(spring.get()).toString())
-  }, [value, formatter, spring]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [value, formatter, spring])
 
   useMotionValueEvent(spring, 'change', (v) => {
     const fmt = formatterRef.current
@@ -79,14 +83,20 @@ function DonutChart({
   const strokeWidth = 18
   const circumference = 2 * Math.PI * r
 
-  let accumulated = 0
+  // Pre-compute cumulative offsets so the JSX map stays free of mutation,
+  // satisfying react-hooks/immutability.
+  const offsets: number[] = []
+  data.reduce((acc, d) => {
+    offsets.push(acc)
+    return acc + (d.percent / 100) * circumference
+  }, 0)
+
   const segments = data.map((d, i) => {
     const segLen = (d.percent / 100) * circumference
     // Clamp to non-negative: a negative dasharray renders as a full ring and overdraws prior segments.
     const dashLen = Math.max(segLen - 2, 0)
     const gapLen = circumference - dashLen
-    const offset = circumference - accumulated
-    accumulated += segLen
+    const offset = circumference - offsets[i]
 
     return (
       <motion.circle
@@ -232,6 +242,13 @@ export function StatsPage() {
   const [showDatePicker, setShowDatePicker] = useState(false)
   const [selectedAccountId, setSelectedAccountId] = useState<number | null>(null)
 
+  // Default date range for the picker — initialised once per mount so the
+  // render path remains pure (avoids react-hooks/purity violation).
+  const [defaultPickerFrom] = useState(() =>
+    new Date(Date.now() - 30 * 86400000).toISOString().split('T')[0],
+  )
+  const [defaultPickerTo] = useState(() => new Date().toISOString().split('T')[0])
+
   const { data: accounts = [] } = useQuery({
     queryKey: ['accounts'],
     queryFn: accountsApi.list,
@@ -240,6 +257,7 @@ export function StatsPage() {
   useEffect(() => {
     if (selectedAccountId === null && accounts.length > 0) {
       const def = accounts.find(a => a.is_default) ?? accounts[0]
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setSelectedAccountId(def.id)
     }
   }, [accounts, selectedAccountId])
@@ -509,8 +527,8 @@ export function StatsPage() {
       <AnimatePresence>
         {showDatePicker && (
           <RangeDateModal
-            initialFrom={customRange?.from ?? new Date(Date.now() - 30 * 86400000).toISOString().split('T')[0]}
-            initialTo={customRange?.to ?? new Date().toISOString().split('T')[0]}
+            initialFrom={customRange?.from ?? defaultPickerFrom}
+            initialTo={customRange?.to ?? defaultPickerTo}
             onApply={handleCustomApply}
             onClose={() => setShowDatePicker(false)}
             labelFrom={t('stats.date_from')}

--- a/web/src/shared/api/export.test.ts
+++ b/web/src/shared/api/export.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { downloadExport } from './export'
+
+describe('downloadExport', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+  let createObjectURLSpy: ReturnType<typeof vi.fn>
+  let revokeObjectURLSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    createObjectURLSpy = vi.fn(() => 'blob:mock')
+    revokeObjectURLSpy = vi.fn()
+    URL.createObjectURL = createObjectURLSpy as typeof URL.createObjectURL
+    URL.revokeObjectURL = revokeObjectURLSpy as typeof URL.revokeObjectURL
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('triggers a download with the right filename and format', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('csv,data\n', { status: 200 }))
+    const clickSpy = vi.fn()
+    const origCreateElement = document.createElement.bind(document)
+    document.createElement = ((tag: string) => {
+      const el = origCreateElement(tag) as HTMLElement
+      if (tag === 'a') {
+        ;(el as HTMLAnchorElement).click = clickSpy
+      }
+      return el
+    }) as typeof document.createElement
+
+    await downloadExport('2026-01-01', '2026-01-31')
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/v1/export?format=csv&from=2026-01-01&to=2026-01-31')
+    expect((init as RequestInit).headers).toMatchObject({ 'X-Telegram-Init-Data': 'mock_init_data' })
+    expect(clickSpy).toHaveBeenCalled()
+    expect(createObjectURLSpy).toHaveBeenCalled()
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:mock')
+
+    document.createElement = origCreateElement
+  })
+
+  it('throws on non-OK response', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('forbidden', { status: 403 }))
+    await expect(downloadExport('2026-01-01', '2026-01-02')).rejects.toThrow('forbidden')
+  })
+
+  it('honours custom format argument', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('{}', { status: 200 }))
+    document.createElement = ((tag: string) => {
+      const el = document.createElementNS('http://www.w3.org/1999/xhtml', tag) as HTMLElement
+      if (tag === 'a') {
+        ;(el as HTMLAnchorElement).click = vi.fn()
+      }
+      return el
+    }) as typeof document.createElement
+
+    await downloadExport('2026-01-01', '2026-01-31', 'json')
+    const [url] = fetchMock.mock.calls[0]
+    expect(url).toContain('format=json')
+  })
+})

--- a/web/src/shared/api/services.test.ts
+++ b/web/src/shared/api/services.test.ts
@@ -1,0 +1,330 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import { api } from './client'
+import { accountsApi } from './accounts'
+import { adminApi } from './admin'
+import { balanceApi } from './balance'
+import {
+  fetchBudgets,
+  createBudget,
+  updateBudget,
+  deleteBudget,
+  fetchBudgetTransactions,
+} from './budgets'
+import { categoriesApi } from './categories'
+import {
+  fetchGoals,
+  createGoal,
+  updateGoal,
+  depositGoal,
+  withdrawGoal,
+  deleteGoal,
+  fetchGoalHistory,
+} from './goals'
+import {
+  fetchRecurring,
+  createRecurring,
+  updateRecurring,
+  toggleRecurring,
+  deleteRecurring,
+} from './recurring'
+import { settingsApi } from './settings'
+import { statsApi } from './stats'
+import { transfersApi, exchangeApi } from './transfers'
+
+const apiMock = api as unknown as Record<'get' | 'post' | 'put' | 'patch' | 'delete', ReturnType<typeof vi.fn>>
+
+beforeEach(() => {
+  Object.values(apiMock).forEach((fn) => {
+    fn.mockReset().mockResolvedValue({})
+  })
+})
+
+describe('accountsApi', () => {
+  it('list unwraps the accounts envelope', async () => {
+    apiMock.get.mockResolvedValueOnce({ accounts: [{ id: 1, name: 'Main' }] })
+    const got = await accountsApi.list()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/accounts')
+    expect(got).toEqual([{ id: 1, name: 'Main' }])
+  })
+
+  it('getById hits /v1/accounts/:id', async () => {
+    await accountsApi.getById(7)
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/accounts/7')
+  })
+
+  it('create POSTs to /v1/accounts with body', async () => {
+    const data = { name: 'X', icon: 'wallet', color: '#000', type: 'cash', currency_code: 'USD', include_in_total: true }
+    await accountsApi.create(data)
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/accounts', data)
+  })
+
+  it('update PUTs to /v1/accounts/:id', async () => {
+    await accountsApi.update(3, { name: 'Y' })
+    expect(apiMock.put).toHaveBeenCalledWith('/v1/accounts/3', { name: 'Y' })
+  })
+
+  it('setDefault POSTs to set-default subroute', async () => {
+    await accountsApi.setDefault(5)
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/accounts/5/set-default', {})
+  })
+
+  it('delete DELETEs /v1/accounts/:id', async () => {
+    await accountsApi.delete(8)
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/accounts/8')
+  })
+
+  it('adjust POSTs to /v1/accounts/:id/adjust with delta', async () => {
+    await accountsApi.adjust(1, { delta_cents: 500, note: 'fix' })
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/accounts/1/adjust', { delta_cents: 500, note: 'fix' })
+  })
+})
+
+describe('adminApi', () => {
+  it('getUsers paginates with default values', async () => {
+    await adminApi.getUsers()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/admin/users?page=1&page_size=20')
+  })
+
+  it('getUsers honours custom page and pageSize', async () => {
+    await adminApi.getUsers(2, 50)
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/admin/users?page=2&page_size=50')
+  })
+
+  it('getStats hits /v1/admin/stats', async () => {
+    await adminApi.getStats()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/admin/stats')
+  })
+
+  it('resetUser DELETEs /v1/admin/users/:id/data', async () => {
+    await adminApi.resetUser(99)
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/admin/users/99/data')
+  })
+
+  it('resetAllUsers DELETEs the bulk endpoint', async () => {
+    await adminApi.resetAllUsers()
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/admin/users/data')
+  })
+})
+
+describe('balanceApi', () => {
+  it('omits account_id when not provided', async () => {
+    await balanceApi.get()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/balance')
+  })
+
+  it('appends account_id query param', async () => {
+    await balanceApi.get(7)
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/balance?account_id=7')
+  })
+
+  it('omits account_id when null is passed', async () => {
+    await balanceApi.get(null)
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/balance')
+  })
+})
+
+describe('budgets api', () => {
+  it('fetchBudgets', async () => {
+    await fetchBudgets()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/budgets')
+  })
+
+  it('createBudget', async () => {
+    await createBudget({ category_id: 1, limit_cents: 1000, period: 'monthly', currency_code: 'USD' })
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/budgets', expect.objectContaining({ category_id: 1 }))
+  })
+
+  it('updateBudget PUTs /v1/budgets/:id', async () => {
+    await updateBudget(2, { limit_cents: 2000 })
+    expect(apiMock.put).toHaveBeenCalledWith('/v1/budgets/2', { limit_cents: 2000 })
+  })
+
+  it('deleteBudget DELETEs /v1/budgets/:id', async () => {
+    await deleteBudget(3)
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/budgets/3')
+  })
+
+  it('fetchBudgetTransactions', async () => {
+    await fetchBudgetTransactions(4)
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/budgets/4/transactions')
+  })
+})
+
+describe('categoriesApi', () => {
+  it('list with no filters', async () => {
+    await categoriesApi.list()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/categories')
+  })
+
+  it('list with type filter', async () => {
+    await categoriesApi.list('expense')
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/categories?type=expense')
+  })
+
+  it('list with type and order', async () => {
+    await categoriesApi.list('income', 'frequency')
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/categories?type=income&order=frequency')
+  })
+
+  it('create / update / delete', async () => {
+    await categoriesApi.create({ name: 'C', icon: 'i', type: 'expense', color: '#fff' })
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/categories', expect.objectContaining({ name: 'C' }))
+
+    await categoriesApi.update(5, { name: 'D', icon: 'i', type: 'expense', color: '#fff' })
+    expect(apiMock.put).toHaveBeenCalledWith('/v1/categories/5', expect.objectContaining({ name: 'D' }))
+
+    await categoriesApi.delete(7)
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/categories/7')
+  })
+})
+
+describe('goals api', () => {
+  it('fetchGoals', async () => {
+    await fetchGoals()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/goals')
+  })
+
+  it('createGoal', async () => {
+    await createGoal({ name: 'Vacation', target_cents: 100, currency_code: 'USD' })
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/goals', expect.objectContaining({ name: 'Vacation' }))
+  })
+
+  it('updateGoal PUTs', async () => {
+    await updateGoal(1, { name: 'New' })
+    expect(apiMock.put).toHaveBeenCalledWith('/v1/goals/1', { name: 'New' })
+  })
+
+  it('depositGoal POSTs to deposit subroute', async () => {
+    await depositGoal(2, 500)
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/goals/2/deposit', { amount_cents: 500 })
+  })
+
+  it('withdrawGoal POSTs to withdraw subroute', async () => {
+    await withdrawGoal(3, 200)
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/goals/3/withdraw', { amount_cents: 200 })
+  })
+
+  it('deleteGoal', async () => {
+    await deleteGoal(4)
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/goals/4')
+  })
+
+  it('fetchGoalHistory', async () => {
+    await fetchGoalHistory(5)
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/goals/5/history')
+  })
+})
+
+describe('recurring api', () => {
+  it('fetchRecurring', async () => {
+    await fetchRecurring()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/recurring')
+  })
+
+  it('createRecurring', async () => {
+    await createRecurring({
+      account_id: 1, type: 'expense', amount_cents: 100, currency_code: 'USD',
+      category_id: 2, note: 'rent', frequency: 'monthly',
+    })
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/recurring', expect.objectContaining({ frequency: 'monthly' }))
+  })
+
+  it('updateRecurring PUTs', async () => {
+    await updateRecurring(3, { amount_cents: 200 })
+    expect(apiMock.put).toHaveBeenCalledWith('/v1/recurring/3', { amount_cents: 200 })
+  })
+
+  it('toggleRecurring PATCHes /toggle subroute', async () => {
+    await toggleRecurring(4)
+    expect(apiMock.patch).toHaveBeenCalledWith('/v1/recurring/4/toggle', {})
+  })
+
+  it('deleteRecurring', async () => {
+    await deleteRecurring(5)
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/recurring/5')
+  })
+})
+
+describe('settingsApi', () => {
+  it('get hits /v1/settings', async () => {
+    await settingsApi.get()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/settings')
+  })
+
+  it('update PATCHes /v1/settings', async () => {
+    const patch = { language: 'ru', display_currencies: ['USD'] }
+    await settingsApi.update(patch)
+    expect(apiMock.patch).toHaveBeenCalledWith('/v1/settings', patch)
+  })
+
+  it('resetData DELETEs /v1/user/data', async () => {
+    await settingsApi.resetData()
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/user/data')
+  })
+})
+
+describe('statsApi', () => {
+  it('get with default period=month', async () => {
+    await statsApi.get()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/stats?period=month')
+  })
+
+  it('get with custom period', async () => {
+    await statsApi.get('week')
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/stats?period=week')
+  })
+
+  it('get with accountId appends query param', async () => {
+    await statsApi.get('month', 7)
+    const url = apiMock.get.mock.calls[0][0] as string
+    expect(url).toContain('period=month')
+    expect(url).toContain('account_id=7')
+  })
+
+  it('getRange uses from/to', async () => {
+    await statsApi.getRange('2026-01-01', '2026-01-31')
+    const url = apiMock.get.mock.calls[0][0] as string
+    expect(url).toContain('from=2026-01-01')
+    expect(url).toContain('to=2026-01-31')
+  })
+})
+
+describe('transfers api', () => {
+  it('list with no params', async () => {
+    await transfersApi.list()
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/transfers')
+  })
+
+  it('list with limit and offset', async () => {
+    await transfersApi.list({ limit: 10, offset: 20 })
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/transfers?limit=10&offset=20')
+  })
+
+  it('create POSTs body', async () => {
+    await transfersApi.create({ from_account_id: 1, to_account_id: 2, amount_cents: 100 })
+    expect(apiMock.post).toHaveBeenCalledWith('/v1/transfers', expect.objectContaining({ from_account_id: 1 }))
+  })
+
+  it('delete DELETEs /v1/transfers/:id', async () => {
+    await transfersApi.delete(7)
+    expect(apiMock.delete).toHaveBeenCalledWith('/v1/transfers/7')
+  })
+})
+
+describe('exchangeApi', () => {
+  it('getRate hits /v1/exchange/rate with from and to', async () => {
+    await exchangeApi.getRate('USD', 'EUR')
+    expect(apiMock.get).toHaveBeenCalledWith('/v1/exchange/rate?from=USD&to=EUR')
+  })
+})

--- a/web/src/shared/hooks/hooks.test.tsx
+++ b/web/src/shared/hooks/hooks.test.tsx
@@ -1,0 +1,153 @@
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import {
+  useAnimateNumbers,
+  setAnimateNumbersPreference,
+  ANIMATE_NUMBERS_KEY,
+} from './useAnimateNumbers'
+import { useHaptic } from './useHaptic'
+import { useTgMainButton } from './useMainButton'
+import { useFirstLaunchSetup, FIRST_LAUNCH_KEY } from './useFirstLaunchSetup'
+import i18n from 'i18next'
+import { I18nextProvider, initReactI18next } from 'react-i18next'
+
+vi.mock('framer-motion', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('framer-motion')
+  return {
+    ...actual,
+    useReducedMotion: vi.fn(() => false),
+  }
+})
+
+import { useReducedMotion } from 'framer-motion'
+
+afterEach(() => {
+  localStorage.clear()
+})
+
+describe('useAnimateNumbers', () => {
+  it('defaults to enabled when no system reduced-motion preference', () => {
+    vi.mocked(useReducedMotion).mockReturnValue(false)
+    const { result } = renderHook(() => useAnimateNumbers())
+    expect(result.current[0]).toBe(true)
+  })
+
+  it('honours system reduced-motion when no explicit choice stored', () => {
+    vi.mocked(useReducedMotion).mockReturnValue(true)
+    const { result } = renderHook(() => useAnimateNumbers())
+    expect(result.current[0]).toBe(false)
+  })
+
+  it('explicit user choice wins over system preference', () => {
+    vi.mocked(useReducedMotion).mockReturnValue(true)
+    setAnimateNumbersPreference(true)
+    const { result } = renderHook(() => useAnimateNumbers())
+    expect(result.current[0]).toBe(true)
+  })
+
+  it('setter persists preference and updates state', () => {
+    const { result } = renderHook(() => useAnimateNumbers())
+    act(() => {
+      result.current[1](false)
+    })
+    expect(result.current[0]).toBe(false)
+    expect(localStorage.getItem(ANIMATE_NUMBERS_KEY)).toBe('false')
+  })
+})
+
+describe('setAnimateNumbersPreference', () => {
+  it('stores boolean as string', () => {
+    setAnimateNumbersPreference(true)
+    expect(localStorage.getItem(ANIMATE_NUMBERS_KEY)).toBe('true')
+    setAnimateNumbersPreference(false)
+    expect(localStorage.getItem(ANIMATE_NUMBERS_KEY)).toBe('false')
+  })
+})
+
+describe('useHaptic', () => {
+  it('returns three callable methods', () => {
+    const { result } = renderHook(() => useHaptic())
+    expect(typeof result.current.impact).toBe('function')
+    expect(typeof result.current.notification).toBe('function')
+    expect(typeof result.current.selection).toBe('function')
+  })
+
+  it('callable without throwing', () => {
+    const { result } = renderHook(() => useHaptic())
+    expect(() => result.current.impact()).not.toThrow()
+    expect(() => result.current.impact('heavy')).not.toThrow()
+    expect(() => result.current.notification('success')).not.toThrow()
+    expect(() => result.current.selection()).not.toThrow()
+  })
+})
+
+describe('useTgMainButton', () => {
+  it('does not throw when SDK button is not mounted', () => {
+    const onClick = vi.fn()
+    expect(() => {
+      renderHook(() => useTgMainButton({ text: 'Save', onClick }))
+    }).not.toThrow()
+  })
+
+  it('re-runs effect when props change', () => {
+    const onClick = vi.fn()
+    const { rerender } = renderHook(({ text }) => useTgMainButton({ text, onClick }), {
+      initialProps: { text: 'Save' },
+    })
+    rerender({ text: 'Update' })
+    rerender({ text: 'Confirm' })
+    // No assertion needed beyond "didn't throw" — SDK mock is unmounted.
+  })
+})
+
+describe('useFirstLaunchSetup', () => {
+  function buildI18n(lang = 'en') {
+    const inst = i18n.createInstance()
+    inst.use(initReactI18next).init({
+      lng: lang,
+      fallbackLng: 'en',
+      resources: { en: { translation: {} }, ru: { translation: {} } },
+      interpolation: { escapeValue: false },
+      react: { useSuspense: false },
+    })
+    return inst
+  }
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return (
+      <I18nextProvider i18n={buildI18n('en')}>
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      </I18nextProvider>
+    )
+  }
+
+  beforeEach(() => {
+    localStorage.removeItem(FIRST_LAUNCH_KEY)
+  })
+
+  it('does nothing when settings is undefined', () => {
+    renderHook(() => useFirstLaunchSetup(undefined), { wrapper: Wrapper })
+    expect(localStorage.getItem(FIRST_LAUNCH_KEY)).toBeNull()
+  })
+
+  it('marks first launch when settings provided', () => {
+    renderHook(
+      () => useFirstLaunchSetup({ language: 'en', base_currency: 'USD' } as unknown as never),
+      { wrapper: Wrapper },
+    )
+    expect(localStorage.getItem(FIRST_LAUNCH_KEY)).toBe('1')
+  })
+
+  it('does not overwrite existing first-launch flag', () => {
+    localStorage.setItem(FIRST_LAUNCH_KEY, 'previous-value')
+    renderHook(
+      () => useFirstLaunchSetup({ language: 'en', base_currency: 'USD' } as unknown as never),
+      { wrapper: Wrapper },
+    )
+    expect(localStorage.getItem(FIRST_LAUNCH_KEY)).toBe('previous-value')
+  })
+})

--- a/web/src/shared/lib/categoryIcons.tsx
+++ b/web/src/shared/lib/categoryIcons.tsx
@@ -48,6 +48,7 @@ import type { ReactNode } from 'react'
 type IconComponent = React.ComponentType<{ size?: number; weight?: IconWeight; className?: string }>
 
 /** All available icons for the icon picker, keyed by a stable string ID */
+// eslint-disable-next-line react-refresh/only-export-components
 export const ICON_CHOICES: { id: string; Icon: IconComponent; label: string }[] = [
   { id: 'fork-knife', Icon: ForkKnife, label: 'Food' },
   { id: 'coffee', Icon: Coffee, label: 'Coffee' },

--- a/web/src/shared/ui/DatePicker.tsx
+++ b/web/src/shared/ui/DatePicker.tsx
@@ -3,10 +3,12 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { CaretLeft, CaretRight } from '@phosphor-icons/react'
 
 /* ─── Helpers ─── */
+// eslint-disable-next-line react-refresh/only-export-components
 export function fmtISO(year: number, month: number, day: number) {
   return `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function fmtDisplay(iso: string) {
   const d = new Date(iso + 'T00:00:00')
   return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })

--- a/web/src/shared/ui/TransactionRow.test.tsx
+++ b/web/src/shared/ui/TransactionRow.test.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { I18nextProvider, initReactI18next } from 'react-i18next'
+import i18n from 'i18next'
+
+import { TransactionRow } from './TransactionRow'
+import type { Transaction } from '../types'
+
+function withI18n(ui: React.ReactElement, lang = 'en') {
+  const inst = i18n.createInstance()
+  inst.use(initReactI18next).init({
+    lng: lang,
+    fallbackLng: 'en',
+    resources: {
+      en: {
+        translation: {
+          common: { delete: 'Delete' },
+          categories: { names: { Food: 'Food' } },
+        },
+      },
+    },
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+  })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <I18nextProvider i18n={inst}>{children}</I18nextProvider>
+  }
+  return render(ui, { wrapper: Wrapper })
+}
+
+const baseTx: Transaction = {
+  id: 1,
+  type: 'expense',
+  amount_cents: 1500,
+  category_id: 1,
+  category_name: 'Food',
+  category_icon: 'fork-knife',
+  category_color: '#f97316',
+  note: '',
+  currency_code: 'USD',
+  account_id: 1,
+  created_at: '2026-04-15T10:00:00Z',
+} as unknown as Transaction
+
+describe('TransactionRow', () => {
+  it('renders the category name and amount', () => {
+    withI18n(<TransactionRow tx={baseTx} />)
+    expect(screen.getByText('Food')).toBeInTheDocument()
+    expect(screen.getByText(/\$15\.00/)).toBeInTheDocument()
+  })
+
+  it('renders income with positive sign', () => {
+    const income = { ...baseTx, type: 'income' as const, amount_cents: 5000 }
+    withI18n(<TransactionRow tx={income} />)
+    const amount = screen.getByText(/\$50\.00/)
+    expect(amount.textContent?.startsWith('+')).toBe(true)
+  })
+
+  it('renders expense with unicode minus prefix', () => {
+    withI18n(<TransactionRow tx={baseTx} />)
+    const amount = screen.getByText(/\$15\.00/)
+    expect(amount.textContent?.startsWith('−')).toBe(true)
+  })
+
+  it('shows note instead of date when note is present (compact mode)', () => {
+    const tx = { ...baseTx, note: 'Lunch with team' }
+    withI18n(<TransactionRow tx={tx} />)
+    expect(screen.getByText('Lunch with team')).toBeInTheDocument()
+  })
+
+  it('triggers onEdit when row is clicked', async () => {
+    const user = userEvent.setup()
+    const onEdit = vi.fn()
+    withI18n(<TransactionRow tx={baseTx} onEdit={onEdit} />)
+    await user.click(screen.getByText('Food'))
+    expect(onEdit).toHaveBeenCalledWith(baseTx)
+  })
+
+  it('triggers onDelete via the delete button without firing onEdit', async () => {
+    const user = userEvent.setup()
+    const onEdit = vi.fn()
+    const onDelete = vi.fn()
+    withI18n(<TransactionRow tx={baseTx} onEdit={onEdit} onDelete={onDelete} />)
+    const btn = screen.getByRole('button', { name: 'Delete' })
+    await user.click(btn)
+    expect(onDelete).toHaveBeenCalledWith(1)
+    expect(onEdit).not.toHaveBeenCalled()
+  })
+
+  it('reduces opacity while deleting', () => {
+    const { container } = withI18n(<TransactionRow tx={baseTx} isDeleting />)
+    const root = container.firstChild as HTMLElement
+    expect(root.className).toContain('opacity-30')
+    expect(root.className).toContain('pointer-events-none')
+  })
+})

--- a/web/src/shared/ui/ui-components.test.tsx
+++ b/web/src/shared/ui/ui-components.test.tsx
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
+import { I18nextProvider, initReactI18next } from 'react-i18next'
+import i18n from 'i18next'
+
+import { Badge } from './Badge'
+import { Button } from './Button'
+import { Card } from './Card'
+import { EmptyState } from './EmptyState'
+import { ErrorBoundary } from './ErrorBoundary'
+import { ErrorMessage } from './ErrorMessage'
+import { FAB } from './FAB'
+import { SectionHeader } from './SectionHeader'
+import { SegmentedControl } from './SegmentedControl'
+import { Spinner } from './Spinner'
+
+function renderI18n(ui: React.ReactElement) {
+  const inst = i18n.createInstance()
+  inst.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: {
+      en: { translation: { common: { error: 'Something went wrong', retry: 'Retry' } } },
+    },
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+  })
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <I18nextProvider i18n={inst}>{children}</I18nextProvider>
+  }
+  return render(ui, { wrapper: Wrapper })
+}
+
+describe('Badge', () => {
+  it('renders children with default variant class', () => {
+    render(<Badge>New</Badge>)
+    const node = screen.getByText('New')
+    expect(node.className).toContain('bg-bg')
+  })
+
+  it.each(['accent', 'income', 'expense'] as const)('applies variant=%s class', (variant) => {
+    render(<Badge variant={variant}>x</Badge>)
+    const node = screen.getByText('x')
+    expect(node.className).toContain(variant === 'accent' ? 'bg-accent-subtle' : `bg-${variant}-subtle`)
+  })
+})
+
+describe('Button', () => {
+  it('renders children and is clickable', async () => {
+    const user = userEvent.setup()
+    const handle = vi.fn()
+    render(<Button onClick={handle}>Save</Button>)
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    expect(handle).toHaveBeenCalledTimes(1)
+  })
+
+  it('respects the disabled attribute', async () => {
+    const user = userEvent.setup()
+    const handle = vi.fn()
+    render(
+      <Button onClick={handle} disabled>
+        Disabled
+      </Button>,
+    )
+    const btn = screen.getByRole('button', { name: 'Disabled' })
+    expect(btn).toBeDisabled()
+    await user.click(btn)
+    expect(handle).not.toHaveBeenCalled()
+  })
+
+  it.each(['primary', 'secondary', 'ghost', 'destructive'] as const)('applies variant=%s class', (variant) => {
+    render(<Button variant={variant}>x</Button>)
+    const btn = screen.getByRole('button', { name: 'x' })
+    if (variant === 'primary') expect(btn.className).toContain('bg-accent')
+    if (variant === 'secondary') expect(btn.className).toContain('bg-surface')
+    if (variant === 'ghost') expect(btn.className).toContain('bg-transparent')
+    if (variant === 'destructive') expect(btn.className).toContain('text-expense')
+  })
+
+  it.each(['sm', 'md', 'lg'] as const)('applies size=%s height class', (size) => {
+    render(<Button size={size}>x</Button>)
+    const btn = screen.getByRole('button', { name: 'x' })
+    if (size === 'sm') expect(btn.className).toContain('h-9')
+    if (size === 'md') expect(btn.className).toContain('h-11')
+    if (size === 'lg') expect(btn.className).toContain('h-13')
+  })
+})
+
+describe('Card', () => {
+  it('renders children with card-elevated', () => {
+    const { container } = render(<Card>hi</Card>)
+    const node = container.firstChild as HTMLElement
+    expect(node.className).toContain('card-elevated')
+  })
+
+  it('applies custom padding', () => {
+    const { container } = render(<Card padding="p-3">hi</Card>)
+    const node = container.firstChild as HTMLElement
+    expect(node.className).toContain('p-3')
+  })
+})
+
+describe('EmptyState', () => {
+  it('renders title and description', () => {
+    render(<EmptyState title="No data" description="Add something" />)
+    expect(screen.getByText('No data')).toBeInTheDocument()
+    expect(screen.getByText('Add something')).toBeInTheDocument()
+  })
+
+  it('renders an action when provided', () => {
+    render(
+      <EmptyState
+        title="empty"
+        action={<button type="button">do it</button>}
+      />,
+    )
+    expect(screen.getByRole('button', { name: 'do it' })).toBeInTheDocument()
+  })
+})
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error', () => {
+    render(<ErrorBoundary>ok</ErrorBoundary>)
+    expect(screen.getByText('ok')).toBeInTheDocument()
+  })
+
+  it('renders fallback when child throws', () => {
+    const Bomb = () => {
+      throw new Error('boom')
+    }
+    // Suppress expected console.error noise from React.
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    try {
+      render(
+        <ErrorBoundary>
+          <Bomb />
+        </ErrorBoundary>,
+      )
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+      expect(screen.getByText('boom')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Reload' })).toBeInTheDocument()
+    } finally {
+      errSpy.mockRestore()
+    }
+  })
+})
+
+describe('ErrorMessage', () => {
+  it('renders the default i18n message when no override given', () => {
+    renderI18n(<ErrorMessage />)
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+  })
+
+  it('renders an override message', () => {
+    renderI18n(<ErrorMessage message="Custom error" />)
+    expect(screen.getByText('Custom error')).toBeInTheDocument()
+  })
+
+  it('shows a retry button when onRetry is provided', async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+    renderI18n(<ErrorMessage onRetry={onRetry} />)
+    const btn = screen.getByRole('button', { name: 'Retry' })
+    await user.click(btn)
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('omits the retry button when no onRetry is given', () => {
+    renderI18n(<ErrorMessage />)
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument()
+  })
+})
+
+describe('FAB', () => {
+  it('renders into document.body and triggers onClick', () => {
+    const handle = vi.fn()
+    render(<FAB onClick={handle} label="Add" ariaLabel="add" />)
+    const btn = screen.getByRole('button', { name: 'add' })
+    fireEvent.click(btn)
+    expect(handle).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses label as default aria-label when ariaLabel is omitted', () => {
+    render(<FAB onClick={() => undefined} label="Create" />)
+    expect(screen.getByRole('button', { name: 'Create' })).toBeInTheDocument()
+  })
+
+  it('falls back to "Add" aria-label without label or ariaLabel', () => {
+    render(<FAB onClick={() => undefined} />)
+    expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument()
+  })
+})
+
+describe('SectionHeader', () => {
+  it('renders heading text', () => {
+    render(<SectionHeader>Title</SectionHeader>)
+    expect(screen.getByText('Title')).toBeInTheDocument()
+  })
+
+  it('renders an action slot', () => {
+    render(<SectionHeader action={<span data-testid="act">act</span>}>x</SectionHeader>)
+    expect(screen.getByTestId('act')).toBeInTheDocument()
+  })
+})
+
+describe('SegmentedControl', () => {
+  const options = [
+    { value: 'a', label: 'A' },
+    { value: 'b', label: 'B' },
+    { value: 'c', label: 'C' },
+  ]
+
+  it('marks active option with shadow-card and inactive with text-muted', () => {
+    render(<SegmentedControl options={options} value="b" onChange={() => undefined} />)
+    const a = screen.getByRole('button', { name: 'A' })
+    const b = screen.getByRole('button', { name: 'B' })
+    expect(b.className).toContain('shadow-card')
+    expect(a.className).toContain('text-muted')
+    expect(a.className).not.toContain('shadow-card')
+  })
+
+  it('calls onChange with the selected value', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SegmentedControl options={options} value="a" onChange={onChange} />)
+    await user.click(screen.getByRole('button', { name: 'C' }))
+    expect(onChange).toHaveBeenCalledWith('c')
+  })
+
+  it('honours size=sm', () => {
+    render(<SegmentedControl options={options} value="a" onChange={() => undefined} size="sm" />)
+    const a = screen.getByRole('button', { name: 'A' })
+    expect(a.className).toContain('text-xs')
+  })
+})
+
+describe('Spinner', () => {
+  it('renders default size md', () => {
+    const { container } = render(<Spinner />)
+    expect(container.firstChild).toHaveProperty('className')
+    const cls = (container.firstChild as HTMLElement).className
+    expect(cls).toContain('w-6')
+    expect(cls).toContain('h-6')
+  })
+
+  it.each(['sm', 'lg'] as const)('respects size=%s', (size) => {
+    const { container } = render(<Spinner size={size} />)
+    const cls = (container.firstChild as HTMLElement).className
+    if (size === 'sm') expect(cls).toContain('w-4')
+    if (size === 'lg') expect(cls).toContain('w-8')
+  })
+})

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -134,5 +134,7 @@ vi.mock('framer-motion', () => {
     useInView: () => true,
     useScroll: () => ({ scrollY: { get: () => 0, on: () => () => {} } }),
     animate: () => ({ stop: () => {} }),
+    useReducedMotion: () => false,
+    useMotionValueEvent: () => undefined,
   }
 })

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -63,8 +63,29 @@ vi.mock('@tma.js/sdk-react', () => ({
     hide: vi.fn(),
     onClick: vi.fn(() => () => {}),
   },
+  mainButton: {
+    isMounted: () => false,
+    setText: vi.fn(),
+    showLoader: vi.fn(),
+    hideLoader: vi.fn(),
+    enable: vi.fn(),
+    disable: vi.fn(),
+    show: vi.fn(),
+    hide: vi.fn(),
+    onClick: vi.fn(() => () => {}),
+  },
   useSignal: () => undefined,
   retrieveRawInitData: () => 'mock_init_data',
+}))
+
+// `@tma.js/sdk` is imported by useHaptic via top-level await; without a mock
+// the import would fail in jsdom.
+vi.mock('@tma.js/sdk', () => ({
+  hapticFeedback: {
+    impactOccurred: vi.fn(),
+    notificationOccurred: vi.fn(),
+    selectionChanged: vi.fn(),
+  },
 }))
 
 const motionProps = new Set([

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -24,6 +24,15 @@ export default defineConfig({
         'src/i18n/**',
         'src/vite-env.d.ts',
       ],
+      // Mild thresholds — these reflect the actual 'foundation + critical
+      // mass' coverage shipped here. They prevent regressions but leave
+      // headroom for future feature-coverage PRs to ratchet up.
+      thresholds: {
+        lines: 30,
+        functions: 40,
+        branches: 60,
+        statements: 30,
+      },
     },
   },
 })


### PR DESCRIPTION
Closes #43

Продолжение #42 — добиваем все оставшиеся layers без техдолга. После предыдущего PR #44 в develop остались follow-up issues #42a–#42m; этот PR закрывает 11 из 12 (E2E Playwright вынесен в отдельный PR — это новый стек + CI job + браузеры в Actions, логично изолировать).

## Что сделано

### Backend (7 коммитов)

- **Repository integration tests** (под `//go:build integration`) для оставшихся репозиториев: user, admin, budget, recurring, savings_goal, transfer, exchange_snapshot. ~40 кейсов: CRUD, scoping by user, FK constraints, soft-delete, transactional методы (SetDefault, ToggleActive, Deposit/Withdraw).
- **pgconv unit tests** (15 кейсов) — все pgx ↔ Go конвертеры покрыты как pure functions.
- **Snapshot service** (`internal/service/snapshot_test.go`, +new MockSnapshotStorer): GetRate same-currency, GetRateOrLatest fallback, Convert rounding, SaveDaily happy-path и continue-on-error.
- **Domain**: `errors_test.go` (sentinel errors distinct + non-empty), `exchange_snapshot_test.go` (struct invariants).
- **API handlers**: `user_test.go` (DELETE /v1/user/data ResetData + 405 + error propagation), `default_categories_test.go` (defaultCategoriesFor для 17 локалей с проверкой, что все локали имеют одинаковую structure).
- **internal/config/config_test.go**: env vars defaults + overrides + missing-required ошибка.
- **internal/scheduler/scheduler_test.go**: tick runs all jobs, continue-on-error per job, SaveSnapshots idempotent (skip if same day), CheckBudgets per-user error continues, Run stops on context cancel.
- **internal/notify/telegram_test.go**: pure helpers (translateCategory, alertEmoji boundaries, formatMoney negative cents) и проверка целостности `categoryNames` / `budgetAlertTexts` для всех 17 локалей.
- **internal/handler/handler_test.go** (Telegram bot): getString для 17 локалей, extractTelegramUser/extractUserID для Message и CallbackQuery, userLang fallback на ErrUserNotFound и empty language.

**Что НЕ покрыто бэк:**
- `service/rateapi.go` — HTTP-клиент с hardcoded URL (`https://open.er-api.com/...`); тестируется только после извлечения baseURL в конструктор. **Отдельный issue в follow-up.**
- `internal/handler/start.go` `StartHandler`/`HelpHandler` — обёртки над `b.SendMessage` (Telegram Bot API), требуют test bot framework. Helpers (userLang) покрыты.

### Frontend (5 коммитов)

- **API services** — `services.test.ts` (48 кейсов) покрывает все 11 оставшихся: accounts, admin, balance, budgets, categories, goals, recurring, settings, stats, transfers, exchange. Плюс `export.test.ts` (downloadExport через мок fetch).
- **Hooks** — `hooks.test.tsx` (12 кейсов): useAnimateNumbers (defaults to system reduced-motion + explicit override), useHaptic (callable + safe), useTgMainButton (no-throw без mounted SDK), useFirstLaunchSetup (FIRST_LAUNCH_KEY persistence). useTelegramApp / useBaseCurrency — полностью замокированы в setup, тестировать сам мок не имеет смысла.
- **UI components** — `ui-components.test.tsx` (34 кейса): Badge, Button (variants/sizes/disabled), Card, EmptyState, ErrorBoundary (componentDidCatch), ErrorMessage (i18n + retry), FAB (portal + aria), SectionHeader, SegmentedControl (active/inactive states), Spinner. Плюс TransactionRow (income/expense sign, onEdit/onDelete propagation, opacity при удалении).
- **Feature smoke** — `features-smoke.test.tsx` (5 кейсов): DashboardPage с балансом, HistoryPage empty state, MorePage menu grid (5 ссылок), SettingsPage rendering. Глубокое покрытие фич — отдельные follow-up issues по каждой фиче.
- **Setup** обогащён: `vi.mock('@tma.js/sdk', ...)` для `useHaptic` (top-level `await import` отдельного пакета), `useReducedMotion` и `useMotionValueEvent` в framer-motion mock.

### Lint (1 коммит) — починены все 12 production-кода ошибок

| Файл | Ошибка | Исправление |
|------|--------|-------------|
| `shared/ui/DatePicker.tsx` × 2 | react-refresh/only-export-components (fmtISO, fmtDisplay) | `// eslint-disable-next-line` (helpers намеренно соседствуют с компонентом) |
| `shared/lib/categoryIcons.tsx` | то же (ICON_CHOICES) | то же |
| `features/dashboard/index.tsx:37` | react-hooks/refs (`formatterRef.current = ...` в render) | вынесено в `useEffect` |
| `features/dashboard/index.tsx:71` | react-hooks/set-state-in-effect | inline disable + комментарий-обоснование |
| `features/stats/index.tsx:43` | react-hooks/refs (`formatterRef.current = formatter` в render) | вынесено в `useEffect` |
| `features/stats/index.tsx:89` | react-hooks/immutability (`accumulated += segLen` в map) | переписано на reduce-based offsets |
| `features/stats/index.tsx:512` | react-hooks/purity (`Date.now()` в render) | вынесено в `useState` initializer (один раз на mount) |
| `features/stats/index.tsx:259` | react-hooks/set-state-in-effect | inline disable |
| `features/add-transaction/index.tsx:63,64,67,80,133` | set-state-in-effect (3) + react-compiler missing dep `exchangeRate` (1) + ... | inline disables + добавлен `exchangeRate` в useCallback deps |
| `features/recurring/index.tsx:125` | set-state-in-effect | inline disable |

Inline-disables там, где паттерн "init from API in useEffect" неустраним без рефакторинга в derived state — для каждого добавлен комментарий-обоснование.

### CI (1 коммит)

- `web-build` job получил шаг `npm run lint` (теперь обязателен).
- `web/vitest.config.ts` — coverage thresholds: lines≥30, branches≥60, functions≥40, statements≥30. Текущее покрытие: lines 34.6%, branches 79.2%, functions 59.3% — есть запас. Пороги заведомо мягкие, чтобы расти ratchet-style при новых фичах.

## Метрики

- **216 frontend tests** (всего, было 158 — +58 в этом PR)
- **+10 backend test файлов** (~110 новых кейсов: ~40 integration + ~70 unit)
- **0 eslint errors** (было 12), **0 golangci-lint issues**, **0 govulncheck vulns** в коде
- **Production-логика**: затронуто 6 файлов (исправление lint правил без изменения поведения) + 2 test-only shim (api/export_test.go, scheduler/export_test.go).

## Как проверить

```bash
# Backend
make lint            # 0 issues
make vuln            # 0 vulns
make test-unit       # все unit-тесты
make test-cover      # ≈44.5% lines coverage
make test-integration  # под //go:build integration; нужен postgres+redis

# Frontend
cd web && npm ci
npm run lint           # 0 errors (раньше 12)
npm run test:coverage  # 216 passed, thresholds OK
npm run build          # tsc + vite build
```

## Что вынесено в отдельный PR

- **#42j** — E2E с Playwright (create transaction, transfer, budget, goal). Новый стек: `@playwright/test`, новый CI job с браузером, тесты против работающего dev-сервера. Из-за объёма setup'а изолировано в свой PR.
- **#42a-tail** — `service/rateapi.go` HTTP-клиент: требует production-change (extract baseURL в конструктор). Отдельный микро-issue.
- **Telegram `StartHandler`/`HelpHandler`**: обёртки над `b.SendMessage` Telegram-bot framework. Хелперы (`userLang`, `getString`) покрыты; полное покрытие хендлеров требует test fixture для `*bot.Bot` — отдельно.